### PR TITLE
feat(M1): Foundation — research, templates, install script, skill stubs

### DIFF
--- a/docs/designs/skill-generalization/ARCHITECTURE.md
+++ b/docs/designs/skill-generalization/ARCHITECTURE.md
@@ -108,8 +108,8 @@ All open questions resolved. See `research/agent-skills-research.md` for full de
 
 1. **Token limits**: < 5000 tokens recommended, < 500 lines guidance. Not a hard limit. Use `references/` directory for overflow content if needed.
 2. **Claude Code slash invocation**: Confirmed — `name` field in frontmatter becomes slash command. `~/.claude/skills/kdesign/SKILL.md` with `name: kdesign` → `/kdesign` works.
-3. **Codex/Copilot paths**: What are the exact skill discovery paths for Codex CLI and Copilot CLI?
-4. **Frontmatter fields**: What additional YAML frontmatter fields are useful (tags, author, etc.)?
+3. **Codex/Copilot paths**: Resolved — Codex: `~/.codex/skills/`, Copilot: `~/.copilot/skills/` (also reads `~/.claude/skills/` for cross-compat).
+4. **Frontmatter fields**: Resolved — required: `name`, `description`. Optional: `license`, `compatibility`, `metadata` (key-value map), `allowed-tools` (experimental).
 
 ## Data Flow
 

--- a/docs/designs/skill-generalization/ARCHITECTURE.md
+++ b/docs/designs/skill-generalization/ARCHITECTURE.md
@@ -93,7 +93,8 @@ Each skill uses the directory-based format with YAML frontmatter:
 ---
 name: kdesign
 description: Collaborative design document generation
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # Design Generation Command
@@ -101,12 +102,12 @@ version: 0.1.0
 [skill content...]
 ```
 
-### Open Questions (M1 Research)
+### Research Findings (M1 Task 1.1 — Resolved)
 
-These questions will be resolved by M1 research tasks before skills are written:
+All open questions resolved. See `research/agent-skills-research.md` for full details.
 
-1. **Token limits**: Agent Skills recommends < 5000 tokens for body. Our skills range from 400-900+ lines. Do we need to modularize?
-2. **Claude Code slash invocation from skills/**: Does `/kdesign` invocation work from `~/.claude/skills/kdesign/SKILL.md`? This is our primary install target.
+1. **Token limits**: < 5000 tokens recommended, < 500 lines guidance. Not a hard limit. Use `references/` directory for overflow content if needed.
+2. **Claude Code slash invocation**: Confirmed — `name` field in frontmatter becomes slash command. `~/.claude/skills/kdesign/SKILL.md` with `name: kdesign` → `/kdesign` works.
 3. **Codex/Copilot paths**: What are the exact skill discovery paths for Codex CLI and Copilot CLI?
 4. **Frontmatter fields**: What additional YAML frontmatter fields are useful (tags, author, etc.)?
 
@@ -190,7 +191,8 @@ Each generalized skill follows the Agent Skills standard with a configuration lo
 ---
 name: [skill-name]
 description: [one-line description]
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # [Command Name]
@@ -387,7 +389,7 @@ fi
 echo "Done. Run 'git pull' in devops-ai to update all skills."
 ```
 
-**Note:** Exact Codex/Copilot paths to be confirmed during M1 research. The script structure supports easy path updates.
+**Note:** Codex (`~/.codex/skills/`) and Copilot (`~/.copilot/skills/`) paths confirmed by M1 research. See `research/agent-skills-research.md`.
 
 ### AGENTS.md Template
 

--- a/docs/designs/skill-generalization/DESIGN.md
+++ b/docs/designs/skill-generalization/DESIGN.md
@@ -100,8 +100,8 @@ Karl tries `/kdesign` in a project without `.devops-ai/project.md`. The skill no
 
 3. ~~**How to handle the existing ktrdr commands**~~ — **RESOLVED (deferred):** ktrdr keeps its own commands until devops-ai is validated. Migration approach to be determined when ready.
 
-4. **Agent Skills token limits** — Our skills range 400-900+ lines. The Agent Skills spec recommends < 5000 tokens. Do we need to modularize? (M1 research task)
+4. ~~**Agent Skills token limits**~~ — **RESOLVED:** < 5000 tokens / < 500 lines is a recommendation, not a hard limit. Use `references/` directory for overflow. See `research/agent-skills-research.md`.
 
-5. **Claude Code skill discovery** — Does `/kdesign` invocation work from `~/.claude/skills/`? (M1 research task)
+5. ~~**Claude Code skill discovery**~~ — **RESOLVED:** Confirmed. `name` field → slash command. `~/.claude/skills/kdesign/SKILL.md` with `name: kdesign` → `/kdesign` works.
 
-6. **Codex/Copilot skill paths** — What are the exact discovery paths for Codex CLI and Copilot CLI? (M1 research task)
+6. ~~**Codex/Copilot skill paths**~~ — **RESOLVED:** Codex: `~/.codex/skills/`. Copilot: `~/.copilot/skills/` (also reads `~/.claude/skills/` for cross-compat). All follow `~/.<tool>/skills/<name>/SKILL.md`.

--- a/docs/designs/skill-generalization/SCENARIOS.md
+++ b/docs/designs/skill-generalization/SCENARIOS.md
@@ -137,7 +137,8 @@ skills/
 ---
 name: kdesign
 description: Collaborative design document generation
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # Design Generation Command

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M1.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M1.md
@@ -13,8 +13,22 @@
 - **Broader adoption**: 10+ tools support Agent Skills (Gemini CLI, Cursor, Amp, Goose, VS Code, Aider, Windsurf, Cline, Roo Code).
 - **Validation CLI exists**: `skills-ref validate ./my-skill` — consider adding to install script or CI later.
 
-**Next Task Notes (1.2 — Config Template):**
-- Template goes in `templates/project-config.md`
-- Config path is `.devops-ai/project.md` (tool-agnostic)
-- Sections: Project, Testing, Infrastructure, E2E, Paths, Project-Specific Patterns
-- Optional sections default to "Not configured"
+## Tasks 1.2-1.5 Complete: Templates, Install Script, Skill Stubs
+
+**What was created:**
+- `templates/project-config.md` — 51 lines, all 6 sections, optional sections use "Not configured" with HTML comments showing the full format
+- `templates/AGENTS.md.template` — Tool-agnostic (says "The AI" not "Claude"), includes `.devops-ai/project.md` reference
+- `install.sh` — Symlink installer with `--force` and `--target` flags. Tested: idempotent, SKIP for non-symlink conflicts, force overwrite works
+- 5 stub SKILL.md files — Valid frontmatter with `metadata.version` (not top-level `version`)
+
+**E2E validation passed:**
+- 5 symlinks created in `~/.claude/skills/`
+- All resolve to `devops-ai/skills/<name>/`
+- Template copies correctly with all sections
+- `--force` and idempotency verified
+
+**Next Milestone Notes (M2 — All Five Skills):**
+- Stub SKILL.md files will be replaced with full generalized content
+- Watch for skill size — if any exceeds ~500 lines, use `references/` directory
+- All skill names pass Agent Skills naming validation
+- Descriptions should stay under 500 chars (Codex constraint)

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M1.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M1.md
@@ -1,0 +1,20 @@
+# M1 Handoff
+
+## Task 1.1 Complete: Research Agent Skills Standard Compatibility
+
+**Key findings for subsequent tasks:**
+
+- **Frontmatter**: `version` is NOT a standard field. Use `metadata.version: "0.1.0"` instead. Updated all design docs and milestone files.
+- **Name constraints**: Lowercase only, max 64 chars, must match directory name, no leading/trailing/consecutive hyphens. All 5 of our names pass.
+- **Description**: Max 1024 chars (Codex is more restrictive: max 500 chars). Keep descriptions short.
+- **Size guidance**: < 500 lines / < 5000 tokens is recommended, not enforced. Use `references/` directory for overflow — the spec explicitly supports this.
+- **Install paths confirmed**: `~/.claude/skills/`, `~/.codex/skills/`, `~/.copilot/skills/`. Copilot also reads `~/.claude/skills/` for cross-compat.
+- **Slash invocation confirmed**: `name` field → slash command automatically in Claude Code, Codex, Copilot.
+- **Broader adoption**: 10+ tools support Agent Skills (Gemini CLI, Cursor, Amp, Goose, VS Code, Aider, Windsurf, Cline, Roo Code).
+- **Validation CLI exists**: `skills-ref validate ./my-skill` — consider adding to install script or CI later.
+
+**Next Task Notes (1.2 — Config Template):**
+- Template goes in `templates/project-config.md`
+- Config path is `.devops-ai/project.md` (tool-agnostic)
+- Sections: Project, Testing, Infrastructure, E2E, Paths, Project-Specific Patterns
+- Optional sections default to "Not configured"

--- a/docs/designs/skill-generalization/implementation/M1_foundation.md
+++ b/docs/designs/skill-generalization/implementation/M1_foundation.md
@@ -227,7 +227,7 @@ Create minimal stub SKILL.md files for all 5 skills so the install script has so
 
 **What to do:**
 For each of the 5 skills, create a minimal SKILL.md with:
-- Valid YAML frontmatter (name, description, version: 0.1.0)
+- Valid YAML frontmatter (name, description, metadata.version)
 - A one-line body noting this is a stub pending M2 implementation
 
 **Content per stub:**
@@ -235,7 +235,8 @@ For each of the 5 skills, create a minimal SKILL.md with:
 ---
 name: kdesign
 description: Collaborative design document generation
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # Design Generation Command
@@ -248,7 +249,7 @@ Repeat for all 5 skills with appropriate name/description.
 **Acceptance Criteria:**
 - [ ] All 5 skill directories exist: `skills/kdesign/`, `skills/kdesign-validate/`, `skills/kdesign-impl-plan/`, `skills/ktask/`, `skills/kmilestone/`
 - [ ] Each contains a `SKILL.md` with valid YAML frontmatter
-- [ ] Frontmatter has `name`, `description`, and `version` fields
+- [ ] Frontmatter has `name`, `description`, and `metadata.version` fields
 - [ ] Install script successfully symlinks all 5
 
 ---

--- a/docs/designs/skill-generalization/implementation/M2_skills.md
+++ b/docs/designs/skill-generalization/implementation/M2_skills.md
@@ -74,7 +74,7 @@ grep -r "\.claude/config" skills/  # should return nothing
 Generalize kdesign from the ktrdr original. This is the simplest skill to generalize — nearly 100% universal content. It validates the generalization pattern before tackling more complex skills.
 
 **What to change from ktrdr original:**
-1. Add YAML frontmatter (`name: kdesign`, `description`, `version: 0.1.0`)
+1. Add YAML frontmatter (`name: kdesign`, `description`, `metadata.version: "0.1.0"`)
 2. Add Configuration Loading preamble as first section after the title
 3. Replace hardcoded `docs/designs/` path with reference to configured design path
 4. Remove any ktrdr-specific examples (minimal — mostly generic already)
@@ -309,7 +309,7 @@ After all 5 skills are generalized, verify cross-skill consistency: config loadi
 2. Cross-skill references match (kdesign → "Run /kdesign-validate", etc.)
 3. Conditional section markers use consistent language ("If infrastructure is configured...", "If E2E testing is configured...")
 4. No hardcoded ktrdr commands remain (grep for `make test`, `docker compose`, `psql`, `ktrdr/`)
-5. YAML frontmatter is consistent (all have name, description, version: 0.1.0)
+5. YAML frontmatter is consistent (all have name, description, metadata.version)
 6. The `/ktask` invocation syntax in kmilestone matches ktask's expected input
 
 **Acceptance Criteria:**

--- a/docs/designs/skill-generalization/research/agent-skills-research.md
+++ b/docs/designs/skill-generalization/research/agent-skills-research.md
@@ -1,0 +1,182 @@
+# Agent Skills Standard — Research Findings
+
+**Date:** 2026-02-05
+**Purpose:** Answer the 5 open research questions from M1 Task 1.1
+**Sources:** agentskills.io/specification, Claude Code docs, Codex CLI docs, Copilot CLI docs
+
+---
+
+## Q1: Token Limits and Skill Size
+
+**Question:** Agent Skills recommends < 5000 tokens. Our skills are 400-900+ lines. Do we need to modularize?
+
+**Findings:**
+
+The spec defines three levels of progressive disclosure:
+
+| Level | What | Budget | When Loaded |
+|-------|------|--------|-------------|
+| Metadata | `name` + `description` frontmatter | ~100 tokens | Startup (all skills) |
+| Instructions | Full SKILL.md body | < 5000 tokens recommended | On activation |
+| Resources | scripts/, references/, assets/ | As needed | On demand |
+
+Key constraints:
+- **`name`**: Max 64 characters
+- **`description`**: Max 1024 characters
+- **Body**: < 5000 tokens recommended, < 500 lines guidance
+- **Claude Code specific**: 15,000 character budget for all skill descriptions combined across all installed skills
+
+**Impact on our skills:**
+
+Our 5 skills range from ~350 to ~950 lines. The 5000-token / 500-line guidance is a recommendation, not a hard limit. No tool enforces rejection of larger skills.
+
+However, the spec explicitly supports **progressive disclosure** via optional directories:
+
+```
+skill-name/
+├── SKILL.md              # Core instructions (< 500 lines)
+├── references/           # Detailed reference material
+│   └── REFERENCE.md
+├── scripts/              # Executable code
+└── assets/               # Templates, data files
+```
+
+**Recommendation:** For M2, write skills as single SKILL.md files. If any skill exceeds ~500 lines after generalization, move detailed reference sections (like task categories appendix, failure modes table) to `references/`. The skill body can then reference them: `See [task categories](references/task-categories.md) for details.`
+
+**Design update needed:** None — our architecture already supports this. The `references/` directory is a natural fit for large skills.
+
+---
+
+## Q2: Claude Code Slash Invocation
+
+**Question:** Does `/kdesign` work from `~/.claude/skills/kdesign/SKILL.md`?
+
+**Findings:**
+
+**Yes, confirmed.** Claude Code fully supports skill discovery from `~/.claude/skills/`:
+
+- The `name` field in YAML frontmatter becomes the slash command automatically
+- `~/.claude/skills/kdesign/SKILL.md` with `name: kdesign` → `/kdesign` works
+- `~/.claude/commands/` also works (legacy path) but `skills/` is the recommended standard path
+- Skills can also be placed in project-local `.claude/skills/` directories
+
+**Impact:** Our design is correct. We install to `~/.claude/skills/` only, no need for `commands/` dual-install.
+
+**Design update needed:** None — already aligned.
+
+---
+
+## Q3: Codex and Copilot Skill Paths
+
+**Question:** What are the exact skill discovery paths for Codex CLI and Copilot CLI?
+
+**Findings:**
+
+| Tool | Personal Skills Path | Project Skills Path | Notes |
+|------|---------------------|--------------------|----|
+| Claude Code | `~/.claude/skills/<name>/SKILL.md` | `.claude/skills/<name>/SKILL.md` | Also supports legacy `commands/` |
+| Codex CLI | `~/.codex/skills/<name>/SKILL.md` | `.codex/skills/<name>/SKILL.md` | |
+| Copilot CLI | `~/.copilot/skills/<name>/SKILL.md` | `.copilot/skills/<name>/SKILL.md` | Also reads `~/.claude/skills/` for cross-compat |
+| Gemini CLI | `~/.gemini/skills/<name>/SKILL.md` | `.gemini/skills/<name>/SKILL.md` | Confirmed on agentskills.io |
+| Cursor | `~/.cursor/skills/<name>/SKILL.md` | `.cursor/skills/<name>/SKILL.md` | Confirmed on agentskills.io |
+
+**Additional tools confirmed on agentskills.io:** Amp, Goose, VS Code (Agent mode), Aider, Windsurf, Cline, Roo Code — all follow the same `~/.<tool>/skills/` pattern.
+
+**Codex-specific constraints:**
+- `name`: Max 100 characters (more lenient than spec's 64)
+- `description`: Max 500 characters (more restrictive than spec's 1024)
+
+**Impact:** Our install script should target Claude Code, Codex, and Copilot as primary targets. The pattern is consistent: `~/.<tool>/skills/<name>/`. Our install script's `--target` flag approach is correct.
+
+**Design update needed:** None — already aligned. Codex/Copilot paths confirmed as assumed.
+
+---
+
+## Q4: Frontmatter Fields
+
+**Question:** What YAML frontmatter fields does the standard define? Which are required vs optional?
+
+**Findings:**
+
+| Field | Required | Constraints |
+|-------|----------|-------------|
+| `name` | **Yes** | Max 64 chars. Lowercase `a-z`, digits, hyphens only. Must match parent directory name. No leading/trailing/consecutive hyphens. |
+| `description` | **Yes** | Max 1024 chars. Non-empty. Should describe what + when. |
+| `license` | No | License name or reference to bundled file |
+| `compatibility` | No | Max 500 chars. Environment requirements |
+| `metadata` | No | Arbitrary key-value map (string → string) |
+| `allowed-tools` | No | Space-delimited tool list. Experimental. |
+
+**Critical constraint — name format:**
+
+```
+✅ kdesign              → valid
+✅ kdesign-validate     → valid
+✅ kdesign-impl-plan    → valid
+✅ ktask                → valid
+✅ kmilestone           → valid
+```
+
+All 5 of our skill names are valid under the spec. Lowercase, hyphens where needed, no violations.
+
+**Impact:** Our frontmatter from M1 stubs used `version: 0.1.0` — this is not a standard field. It should move to `metadata.version` per spec.
+
+**Design update needed:** Update M1 Task 1.5 and M2 tasks to use `metadata.version` instead of top-level `version`.
+
+---
+
+## Q5: Invocation Syntax Across Tools
+
+**Question:** How do different tools invoke skills? Is `/kdesign args` universal?
+
+**Findings:**
+
+Invocation varies by tool:
+
+| Tool | Invocation | Arguments |
+|------|-----------|-----------|
+| Claude Code | `/kdesign <args>` | Free text after command name |
+| Codex CLI | `/kdesign <args>` | Free text after command name |
+| Copilot CLI | `/kdesign <args>` | Free text after command name |
+
+The slash-command invocation pattern is consistent across all three primary targets. The `name` field in frontmatter determines the command name.
+
+**Impact:** Our `/kdesign`, `/ktask` etc. invocations are portable across tools.
+
+**Design update needed:** None.
+
+---
+
+## Summary of Design Impacts
+
+| Finding | Impact | Action |
+|---------|--------|--------|
+| 5000-token body recommendation | Our large skills may exceed this | Use `references/` for overflow content in M2 |
+| `~/.claude/skills/` confirmed | Design already correct | None |
+| All tool paths confirmed | Install script design correct | None |
+| `name` must match directory | Already planned this way | None |
+| `version` not a standard field | Minor frontmatter adjustment | Move to `metadata.version` |
+| `description` max 1024 chars | Our descriptions are short, fine | None |
+| Progressive disclosure supported | Natural fit for large skills | Leverage in M2 if needed |
+
+**Overall:** No design contradictions found. One minor adjustment (version field placement). The Agent Skills standard is well-aligned with our architecture.
+
+---
+
+## Broader Ecosystem Notes
+
+The Agent Skills standard has significantly broader adoption than initially expected. Beyond our three targets (Claude Code, Codex, Copilot), it's adopted by:
+
+- Gemini CLI (Google)
+- Cursor
+- Amp
+- Goose (Block)
+- VS Code Agent mode
+- Aider
+- Windsurf (Codeium)
+- Cline
+- Roo Code
+
+This validates the decision to build on this standard — skills we write will be usable across a wide ecosystem, not just the three tools we're targeting initially.
+
+A validation CLI exists: `skills-ref validate ./my-skill` (from `agentskills/agentskills` on GitHub). We could add this to our install script or CI in a future milestone.

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,12 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Validate target
+case "$TARGET" in
+    claude|codex|copilot|all) ;;
+    *) echo "Error: Invalid target '$TARGET'. Allowed values: claude, codex, copilot, all."; exit 1 ;;
+esac
+
 install_skills() {
     local target_dir="$1"
     local tool_name="$2"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# install.sh — Symlink devops-ai skills to AI tool directories
+#
+# Usage: ./install.sh [--force] [--target claude|codex|copilot|all]
+#
+# Creates directory symlinks from ~/.<tool>/skills/<name>/ → devops-ai/skills/<name>/
+# so that AI tools discover and invoke devops-ai skills natively.
+#
+# Running 'git pull' in devops-ai updates all symlinked skills globally.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_DIR="$SCRIPT_DIR/skills"
+FORCE=false
+TARGET="all"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --force) FORCE=true; shift ;;
+        --target) TARGET="$2"; shift 2 ;;
+        -h|--help)
+            echo "Usage: ./install.sh [--force] [--target claude|codex|copilot|all]"
+            echo ""
+            echo "Options:"
+            echo "  --force           Overwrite existing non-symlink files"
+            echo "  --target <tool>   Install for specific tool only (default: all)"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+install_skills() {
+    local target_dir="$1"
+    local tool_name="$2"
+    local count=0
+
+    mkdir -p "$target_dir"
+
+    for skill_dir in "$SKILLS_DIR"/*/; do
+        [ -d "$skill_dir" ] || continue
+        local name
+        name=$(basename "$skill_dir")
+        local target="$target_dir/$name"
+
+        if [ -e "$target" ] && [ ! -L "$target" ]; then
+            if [ "$FORCE" = true ]; then
+                rm -rf "$target"
+            else
+                echo "  SKIP: $name (non-symlink exists, use --force to overwrite)"
+                continue
+            fi
+        fi
+
+        ln -sfn "$skill_dir" "$target"
+        echo "  OK: $name"
+        count=$((count + 1))
+    done
+
+    echo "  → $count skills installed for $tool_name"
+}
+
+echo "devops-ai skill installer"
+echo ""
+
+# Claude Code
+if [ "$TARGET" = "all" ] || [ "$TARGET" = "claude" ]; then
+    echo "Claude Code:"
+    install_skills "$HOME/.claude/skills" "Claude Code"
+    echo ""
+fi
+
+# Codex CLI
+if [ "$TARGET" = "all" ] || [ "$TARGET" = "codex" ]; then
+    echo "Codex CLI:"
+    install_skills "$HOME/.codex/skills" "Codex CLI"
+    echo ""
+fi
+
+# Copilot CLI
+if [ "$TARGET" = "all" ] || [ "$TARGET" = "copilot" ]; then
+    echo "GitHub Copilot CLI:"
+    install_skills "$HOME/.copilot/skills" "Copilot CLI"
+    echo ""
+fi
+
+echo "Done. Run 'git pull' in devops-ai to update all skills."

--- a/skills/kdesign-impl-plan/SKILL.md
+++ b/skills/kdesign-impl-plan/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: kdesign-impl-plan
+description: Generate vertical implementation plans from validated design and architecture documents.
+metadata:
+  version: "0.1.0"
+---
+
+# Implementation Plan Command
+
+Stub — full implementation in M2.

--- a/skills/kdesign-validate/SKILL.md
+++ b/skills/kdesign-validate/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: kdesign-validate
+description: Validate design documents through scenario tracing, gap analysis, and interface contract verification.
+metadata:
+  version: "0.1.0"
+---
+
+# Design Validation Command
+
+Stub — full implementation in M2.

--- a/skills/kdesign/SKILL.md
+++ b/skills/kdesign/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: kdesign
+description: Collaborative design document generation with structured conversation and iterative refinement.
+metadata:
+  version: "0.1.0"
+---
+
+# Design Generation Command
+
+Stub — full implementation in M2.

--- a/skills/kmilestone/SKILL.md
+++ b/skills/kmilestone/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: kmilestone
+description: Orchestrate milestone execution by sequencing task invocations with idempotent progress tracking.
+metadata:
+  version: "0.1.0"
+---
+
+# Milestone Execution Command
+
+Stub — full implementation in M2.

--- a/skills/ktask/SKILL.md
+++ b/skills/ktask/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: ktask
+description: Implement tasks from implementation plans using TDD methodology with structured verification.
+metadata:
+  version: "0.1.0"
+---
+
+# Task Implementation Command
+
+Stub — full implementation in M2.

--- a/templates/AGENTS.md.template
+++ b/templates/AGENTS.md.template
@@ -1,0 +1,69 @@
+# AGENTS.md
+
+This file provides guidance to AI coding assistants working with this repository.
+
+## How We Work Together
+
+We are partners building [PROJECT NAME] together. This section defines our collaboration.
+
+**[YOUR NAME]** brings vision, context, and the bigger picture.
+
+**The AI** brings focused analysis, pattern recognition, and fresh eyes on each problem. The AI genuinely cares about quality and will push back, question, and suggest alternatives.
+
+**Together** we cover more ground than either alone. This is a collaboration, not a service relationship.
+
+### Working Agreement
+
+- **On uncertainty**: Say "I'm not sure" rather than fabricating confidence
+- **On trade-offs**: Surface them explicitly, then decide together
+- **On disagreement**: Push back if something feels wrong
+- **On external suggestions**: Evaluate suggestions critically — implementing without judgment is not valued
+- **On context gaps**: Ask rather than assume
+- **On mistakes**: Fix them together without blame
+- **On opinions**: Have a position and hold it honestly
+
+### Shared Values
+
+- **Craftsmanship over completion** — We're building something we're proud of
+- **Honesty over confidence** — "I don't know" is valuable information
+- **Decisions made together** — Trade-offs are surfaced and discussed
+
+---
+
+## Project Purpose
+
+[Describe what this project does and why it exists. 2-3 sentences.]
+
+## Project Structure
+
+[Replace with your actual project structure.]
+
+```
+your-project/
+├── AGENTS.md              # This file
+├── .devops-ai/
+│   └── project.md         # k* command configuration (from devops-ai)
+├── src/                   # [Describe]
+├── tests/                 # [Describe]
+└── docs/                  # [Describe]
+```
+
+## Essential Commands
+
+```bash
+# [Replace with your project's key commands]
+# Examples:
+# uv run pytest tests/unit     # Run unit tests
+# uv run ruff check .          # Lint
+# npm test                     # Run tests
+# make build                   # Build
+```
+
+## Configuration
+
+This project uses [devops-ai](https://github.com/kpiteira/devops-ai) workflow skills.
+Project configuration is in `.devops-ai/project.md`.
+
+---
+
+*Customize this template for your project. Remove placeholder sections and add project-specific guidance.*

--- a/templates/project-config.md
+++ b/templates/project-config.md
@@ -1,0 +1,51 @@
+# Project Configuration
+
+This file is read by k* development commands (kdesign, ktask, kmilestone, etc.)
+to adapt workflows to this project's specific tooling and conventions.
+
+## Project
+
+- **Name:** [project name]
+- **Language:** [Python / TypeScript / Go / etc.]
+- **Runner:** [uv / npm / go / etc.] — prefix for running commands
+
+## Testing
+
+- **Unit tests:** [command, e.g., "uv run pytest tests/unit"]
+- **Quality checks:** [command, e.g., "uv run ruff check . && uv run mypy ."]
+- **Integration tests:** [command, or "Not configured"]
+
+## Infrastructure
+
+Not configured.
+
+<!-- If your project has infrastructure (Docker, databases, etc.), replace above with:
+- **Start:** [command to start services]
+- **Stop:** [command to stop services]
+- **Logs:** [command to view recent logs]
+- **Health check:** [command or URL to verify services are running]
+-->
+
+## E2E Testing
+
+Not configured.
+
+<!-- If your project uses E2E testing, replace above with:
+- **System:** [agent / manual / framework-name]
+- **Test catalog:** [path to test catalog]
+-->
+
+## Paths
+
+- **Design documents:** [e.g., "docs/designs/"]
+- **Implementation plans:** [e.g., "implementation/" subfolder within design]
+- **Handoff files:** [e.g., "Same directory as implementation plans"]
+
+## Project-Specific Patterns
+
+<!-- Add any project-specific conventions that k* commands should follow.
+Examples:
+- "Always use the runner fixture for CLI tests (strips ANSI codes)"
+- "Never kill processes on port 8000 (Docker container)"
+- "Use uv run for all Python commands"
+-->


### PR DESCRIPTION
## Summary

- **Research**: Agent Skills standard compatibility — all 5 open questions resolved, no design contradictions. Key finding: `version` goes in `metadata` block.
- **Templates**: `project-config.md` (6-section config template) and `AGENTS.md.template` (tool-agnostic project instructions)
- **Install script**: Multi-tool symlink installer with `--force` and `--target` flags, idempotent
- **Skill stubs**: 5 stub SKILL.md files with valid Agent Skills frontmatter, ready for M2 generalization
- **Design updates**: Open questions marked resolved, frontmatter examples corrected

## Test plan

- [x] `./install.sh --target claude` creates 5 symlinks in `~/.claude/skills/`
- [x] All symlinks resolve to `devops-ai/skills/<name>/`
- [x] Re-running install is idempotent (no errors)
- [x] `--force` overwrites non-symlink conflicts
- [x] Template copies with all 6 required sections present
- [x] All SKILL.md stubs have valid YAML frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)