### PR TITLE
feat(M2): generalize all five k* skills

### DIFF
--- a/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
@@ -16,7 +16,19 @@
 - No-config fallback asks only the questions this skill needs (kdesign: design path + project name)
 - Conversation patterns and pause points preserved exactly from originals
 
-**Next Task Notes (2.2 — kdesign-validate):**
-- Same pattern: frontmatter + config preamble + generalize references
-- Watch for ktrdr-specific command examples (`ktrdr agent trigger`, etc.) — replace with generic
-- Remove "M1 persistence bug" historical reference
+## Task 2.2 Complete: Generalize kdesign-validate
+
+**Changes from original:**
+- Removed all "Karl" references → "You" / "User"
+- Removed ktrdr command examples (`ktrdr agent trigger`, `ktrdr agent status`) → generic placeholders
+- Removed "M1 persistence bug" / checkpoint system example (ktrdr-specific history, lines 600-616)
+- Generalized scenario examples (agent sessions → generic entity patterns)
+- Interface contract examples now use generic entity names
+
+**Size:** 578 lines. Above 500-line guidance but the validation methodology is the core value and shouldn't be split. The conversation patterns section could move to `references/` if needed later.
+
+**Next Task Notes (2.3 — kdesign-impl-plan):**
+- This is the LARGEST skill (944 lines original). Will likely exceed 500 lines.
+- Most ktrdr-specific content: make targets, docker commands, psql queries, ktrdr/ paths
+- Task categories appendix and failure modes table are universal — preserve
+- May need `references/` split for appendix material

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
@@ -75,3 +75,20 @@
 - Extract E2E testing instructions from ktask/kmilestone into shared prompt
 - Referenced by both skills via "If E2E is configured, load shared E2E prompt"
 - Should contain the agent workflow (designer → architect → tester)
+
+## Task 2.6 Complete: Create Shared E2E Prompt
+
+**Size:** 155 lines. Self-contained E2E testing workflow document.
+
+**What it contains:**
+- Three-agent system overview (designer, architect, tester) with roles, models, and when to use each
+- Mandatory workflow Steps 1-4 with concrete invocation examples
+- Anti-patterns and valid vs invalid validation tables
+- Integration guidance for both ktask and kmilestone
+
+**References added:** ktask, kmilestone, and kdesign-impl-plan all reference `skills/shared/e2e-prompt.md` conditionally
+
+**Next Task Notes (2.7 — cross-skill consistency):**
+- Verify all 5 skills + shared prompt
+- Check config preambles, cross-references, conditional markers, frontmatter
+- Grep for any remaining ktrdr-specific content

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
@@ -59,3 +59,19 @@
 - 354 lines original, nearly 100% universal
 - Only ktrdr-specific references are make targets in verification checklist
 - Should match ktask invocation syntax from 2.4
+
+## Task 2.5 Complete: Generalize kmilestone
+
+**Size:** 384 lines (well under 500-line guidance). Nearly 100% universal — minimal changes needed.
+
+**Key changes:**
+- Added Configuration Loading preamble (extracts Testing.*, E2E.* from project config)
+- `make test-unit` / `make quality` in verification checklist → "configured unit test/quality command"
+- E2E VALIDATION reminder made conditional on E2E config
+- ktrdr-specific example paths replaced with generic feature paths
+- Kept validation quality tables (Insufficient vs Valid) with generic examples
+
+**Next Task Notes (2.6 — shared E2E prompt):**
+- Extract E2E testing instructions from ktask/kmilestone into shared prompt
+- Referenced by both skills via "If E2E is configured, load shared E2E prompt"
+- Should contain the agent workflow (designer → architect → tester)

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
@@ -92,3 +92,15 @@
 - Verify all 5 skills + shared prompt
 - Check config preambles, cross-references, conditional markers, frontmatter
 - Grep for any remaining ktrdr-specific content
+
+## Task 2.7 Complete: Cross-Skill Consistency Verification
+
+**All checks passed:**
+- Config preambles: identical structure across all 5 skills
+- Cross-skill references: match SCENARIOS.md table (kdesign→validate→impl-plan→ktask, kmilestone→ktask)
+- Conditional markers: consistent ("If infrastructure is configured", "If E2E testing is configured")
+- Zero ktrdr-specific commands (make test, docker compose, psql, ktrdr/) — only examples in config preambles
+- Frontmatter: all 5 have name, description, metadata.version in identical format
+- ktask invocation: kmilestone uses `/ktask impl: <file> task: <id>`, matches ktask's required params
+- All 5 skills reference `.devops-ai/project.md`, none reference `.claude/config`
+- Shared E2E prompt referenced by ktask, kmilestone, kdesign-impl-plan

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
@@ -27,8 +27,18 @@
 
 **Size:** 578 lines. Above 500-line guidance but the validation methodology is the core value and shouldn't be split. The conversation patterns section could move to `references/` if needed later.
 
-**Next Task Notes (2.3 — kdesign-impl-plan):**
-- This is the LARGEST skill (944 lines original). Will likely exceed 500 lines.
-- Most ktrdr-specific content: make targets, docker commands, psql queries, ktrdr/ paths
-- Task categories appendix and failure modes table are universal — preserve
-- May need `references/` split for appendix material
+## Task 2.3 Complete: Generalize kdesign-impl-plan
+
+**Size:** 974 lines (largest skill). Above 500-line guidance but the planning methodology + appendix tables are the core value. Could move appendix to `references/` later if needed.
+
+**Key changes:**
+- All make/docker/psql commands replaced with config-driven references
+- Infrastructure sections made conditional ("If infrastructure is configured...")
+- E2E sections reference shared prompt
+- Specificity checklist examples use generic paths (`src/services/user.py`)
+- "M1 persistence bug" anecdote generalized to universal explanation
+
+**Next Task Notes (2.4 — ktask):**
+- 431 lines original, moderate ktrdr-specific content
+- Main changes: make targets, docker commands, runner fixture pattern
+- The runner fixture/ANSI codes section is ktrdr-specific — remove entirely, note in config guidance

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
@@ -42,3 +42,20 @@
 - 431 lines original, moderate ktrdr-specific content
 - Main changes: make targets, docker commands, runner fixture pattern
 - The runner fixture/ANSI codes section is ktrdr-specific — remove entirely, note in config guidance
+
+## Task 2.4 Complete: Generalize ktask
+
+**Size:** 447 lines (well under 500-line guidance).
+
+**Key changes:**
+- Added Configuration Loading preamble (extracts Testing.*, Infrastructure.*, E2E.* from project config)
+- All hardcoded `make test-unit`, `make quality`, `docker compose` replaced with "configured command" references
+- Infrastructure sections wrapped in "If infrastructure is configured" conditionals
+- E2E sections wrapped in "If E2E testing is configured" conditionals
+- CLI Test Patterns section (runner fixture, ANSI codes) removed — replaced with generic "Project-Specific Test Patterns" section pointing to `.devops-ai/project.md`
+- Config preamble examples kept as illustrations (e.g., `make test-unit`) — these show what config values might look like, not hardcoded commands
+
+**Next Task Notes (2.5 — kmilestone):**
+- 354 lines original, nearly 100% universal
+- Only ktrdr-specific references are make targets in verification checklist
+- Should match ktask invocation syntax from 2.4

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M2.md
@@ -1,0 +1,22 @@
+# M2 Handoff
+
+## Task 2.1 Complete: Generalize kdesign
+
+**Approach:** kdesign was nearly 100% universal. Changes were minimal:
+- Added YAML frontmatter + Configuration Loading preamble
+- "Karl" → "You" (tool-agnostic)
+- Output Files section references "configured design path" instead of hardcoded `docs/designs/`
+- `docs/designs/` appears only as a default/example, never as a hard requirement
+
+**Size:** 456 lines (under 500-line guidance). No need for `references/` split.
+
+**Pattern established for remaining skills:**
+- Configuration Loading is always the first section after the title
+- Config preamble lists exactly which config values the skill uses
+- No-config fallback asks only the questions this skill needs (kdesign: design path + project name)
+- Conversation patterns and pause points preserved exactly from originals
+
+**Next Task Notes (2.2 — kdesign-validate):**
+- Same pattern: frontmatter + config preamble + generalize references
+- Watch for ktrdr-specific command examples (`ktrdr agent trigger`, etc.) — replace with generic
+- Remove "M1 persistence bug" historical reference

--- a/skills/kdesign-impl-plan/SKILL.md
+++ b/skills/kdesign-impl-plan/SKILL.md
@@ -1,10 +1,974 @@
 ---
 name: kdesign-impl-plan
-description: Generate vertical implementation plans from validated design and architecture documents.
+description: Generate vertical implementation plans from validated design and architecture documents with E2E-testable milestones.
 metadata:
   version: "0.1.0"
 ---
 
 # Implementation Plan Command
 
-Stub — full implementation in M2.
+## Purpose
+
+Generate a vertical implementation plan from validated design and architecture documents. Each milestone delivers an E2E-testable capability, ensuring design problems surface early.
+
+**When to use:** After design validation is complete (via `/kdesign-validate`), when you're ready to break the work into implementable tasks.
+
+**What it produces:**
+- Vertical milestones (each E2E-testable)
+- Detailed tasks with specific files and changes
+- E2E test scenarios for each milestone
+- Acceptance criteria per task
+
+---
+
+## Configuration Loading
+
+**FIRST STEP — Do this before any workflow action.**
+
+1. Read `.devops-ai/project.md` from the project root
+2. If the file exists, extract:
+   - **Testing.unit_tests** — command for running unit tests
+   - **Testing.quality_checks** — command for quality/lint checks
+   - **Infrastructure** — whether infrastructure exists and commands
+   - **E2E** — whether E2E testing is configured
+   - **Paths.design_documents** — where design docs are stored
+3. If the file does NOT exist:
+   - Ask: "What command runs your unit tests?"
+   - Ask: "What command runs quality/lint checks?"
+   - Ask: "Where do you store design documents?" (default: `docs/designs/`)
+   - Note: Infrastructure and E2E features require config. These sections will be skipped.
+   - Suggest creating config for future sessions.
+4. Use the configured values throughout this workflow
+
+---
+
+## This is a Conversation, Not a Generator
+
+The command produces a draft plan. The value comes from refining it together.
+
+Claude will propose milestones based on the design, but:
+
+- **Claude may miss dependencies.** You know what's flaky, what takes longer than expected, what has hidden complexity.
+- **Claude may over-split or under-split.** You know team capacity and what makes sense as a unit of work.
+- **Milestone boundaries are judgment calls.** Claude proposes, you adjust.
+
+The command pauses for feedback at key points. This back-and-forth is how good plans emerge.
+
+---
+
+## Command Usage
+
+```
+/kdesign-impl-plan design: <design-doc.md> arch: <architecture-doc.md> [validation: <validation-output.md>]
+```
+
+**Required:**
+- `design:` — The design/spec document
+- `arch:` — The architecture document
+
+**Optional:**
+- `validation:` — Output from `/kdesign-validate` (contains scenarios, decisions, milestone structure)
+- Additional reference docs
+
+If validation output is provided, Claude uses the scenarios and milestone structure from validation as the starting point.
+
+---
+
+## Plan Generation Process
+
+### Step 0: Architecture Alignment Check
+
+Before planning tasks, Claude must understand and commit to the architecture's core decisions. This prevents implementation drift.
+
+Claude reads the architecture document and extracts:
+
+```markdown
+## Architecture Alignment
+
+### Core Patterns (from ARCHITECTURE.md)
+
+| Pattern | Description | Implementation Approach |
+|---------|-------------|------------------------|
+| [e.g., State Machine] | [What the arch doc says] | [How we'll implement it] |
+| [e.g., Event-Driven] | [What the arch doc says] | [How we'll implement it] |
+| [e.g., Worker Model] | [What the arch doc says] | [How we'll implement it] |
+
+### Key Architectural Decisions
+
+1. **[Decision 1]**: [What the arch says]
+   - Implementation: [How tasks will reflect this]
+
+2. **[Decision 2]**: [What the arch says]
+   - Implementation: [How tasks will reflect this]
+
+### What We Will NOT Do
+
+Based on the architecture, these approaches are explicitly ruled out:
+- [Anti-pattern 1 that would violate the architecture]
+- [Anti-pattern 2 that would violate the architecture]
+```
+
+---
+
+**Pause: Architecture Alignment**
+
+Claude asks:
+
+> "I've extracted these core patterns and decisions from the architecture:
+>
+> **Patterns:** [list]
+> **Key Decisions:** [list]
+> **Ruled Out:** [list]
+>
+> Before I proceed:
+> 1. **Did I understand the architecture correctly?**
+> 2. **Are there patterns I missed?**
+> 3. **Anything in 'ruled out' that's actually acceptable?"
+
+This alignment check is critical. If the architecture says "state machine with explicit transitions," the implementation plan cannot use a "continuous polling loop." Every task must be traceable to an architectural decision.
+
+---
+
+### Step 1: Extract Capabilities
+
+Claude reads the design docs and lists what the user can DO when this feature is complete:
+
+```markdown
+## User Capabilities (when complete)
+
+1. User can trigger an automated research cycle
+2. User can see current status and progress
+3. User can cancel a running cycle
+4. User can see results when complete
+5. User can configure research parameters
+```
+
+---
+
+**Pause: Capability Review**
+
+Claude asks:
+
+> "These are the capabilities I extracted from the design. Before I structure milestones:
+>
+> 1. **Is anything missing?** Capabilities you expect that I didn't list?
+> 2. **What's the priority order?** Which capability is most important to prove first?
+> 3. **Any dependencies I should know about?** Things that must exist before others can work?"
+
+---
+
+### Step 2: Define Milestone 1 (The Foundation)
+
+Milestone 1 is special — it's the smallest thing that proves the architecture works end-to-end. It doesn't need to be useful, just testable.
+
+Claude proposes M1:
+
+```markdown
+## Milestone 1: [Smallest E2E-testable slice]
+
+**Capability:** User can [minimal action]
+**Why this is M1:** [Why this proves the architecture]
+
+**E2E Test Scenario:**
+```bash
+# [Concrete commands that prove it works]
+```
+
+**Layers Touched:**
+- Model: [What's needed]
+- Service: [What's needed]
+- API: [What's needed]
+- CLI: [What's needed, if any]
+```
+
+---
+
+**Pause: M1 Review**
+
+Claude asks:
+
+> "This is my proposed Milestone 1. It touches [N] layers and should be completable in [estimate].
+>
+> 1. **Is this too big?** Should I find a smaller first proof?
+> 2. **Is this too small?** Is there a natural grouping that makes more sense?
+> 3. **Is the E2E test realistic?** Can we actually run this against the system?"
+
+---
+
+### Step 3: Build Remaining Milestones
+
+For each subsequent milestone, Claude proposes:
+
+```markdown
+## Milestone N: [User can X]
+
+**Builds on:** Milestone N-1
+**Capability Added:** [What's new]
+
+**E2E Test Scenario:**
+```bash
+# [Commands that prove this works]
+# [Should also verify previous milestones still work]
+```
+
+**Layers Touched:**
+- [Only what changes from previous milestone]
+```
+
+Claude continues until all capabilities are covered, then presents the full milestone structure.
+
+---
+
+**Pause: Milestone Structure Review**
+
+Claude asks:
+
+> "Here's the full milestone structure:
+>
+> - M1: [capability] (~X tasks)
+> - M2: [capability] (~Y tasks)
+> - M3: [capability] (~Z tasks)
+> ...
+>
+> 1. **Does the order make sense?** Any milestones that should be reordered?
+> 2. **Are the boundaries right?** Any milestones that should be split or merged?
+> 3. **Anything missing?** Capabilities we discussed that aren't covered?"
+
+---
+
+### Step 4: Expand Tasks
+
+For each approved milestone, Claude generates detailed tasks. Each task must trace back to the architecture.
+
+```markdown
+# Milestone N: [User can X]
+
+**Branch:** `feature/[branch-name]`
+**Builds on:** Milestone N-1
+**E2E Test:** [Scenario from above]
+
+---
+
+## Task N.1: [Specific action]
+
+**File:** `path/to/file.py`
+**Action:** Create | Modify | Delete
+**Architectural Pattern:** [Which pattern from Step 0 this implements]
+
+**What to do:**
+[Specific description of the change]
+
+**Code sketch:** (optional, structure only)
+```python
+# Shows patterns and wiring, NOT complete implementation
+# Implementer must read existing code to understand full functionality
+```
+
+**Tests:**
+- Unit: `tests/unit/path/test_file.py`
+- What to test: [Specific behaviors]
+
+**Acceptance Criteria:**
+- [ ] [Specific, verifiable criterion]
+- [ ] [Specific, verifiable criterion]
+- [ ] Implements [pattern] as specified in architecture
+
+---
+
+## Task N.2: [Next task]
+...
+
+---
+
+## Milestone N Verification
+
+### E2E Test Scenario
+
+**Purpose:** [What this test proves]
+**Duration:** ~[N] seconds
+**Prerequisites:** [What must be running/available]
+
+**Test Steps:**
+
+```bash
+# 1. Setup (if needed)
+[commands]
+
+# 2. Trigger the feature
+[commands with expected output comments]
+
+# 3. Verify the result
+[commands to check state/logs/response]
+
+# 4. Cleanup (if needed)
+[commands]
+```
+
+**Success Criteria:**
+- [ ] [Observable outcome 1]
+- [ ] [Observable outcome 2]
+- [ ] If infrastructure is configured: No errors in logs: [INFRA_LOGS_COMMAND from project config]
+
+### Completion Checklist
+
+- [ ] All tasks complete and committed
+- [ ] Unit tests pass: [UNIT_TEST_COMMAND from project config]
+- [ ] E2E test passes (above)
+- [ ] Previous milestone E2E tests still pass
+- [ ] Quality gates pass: [QUALITY_COMMAND from project config]
+- [ ] No regressions introduced
+```
+
+---
+
+### Step 4.5: Test Requirement Analysis
+
+**Before finalizing tasks**, Claude analyzes each task to determine required integration and smoke tests. This prevents "components work but aren't connected" bugs.
+
+**For each task, Claude:**
+
+1. **Identifies Categories** — Read the task description and identify which categories apply (see Appendix: Task Type Categories)
+
+2. **Looks Up Failure Modes** — For each category, consult the failure mode table
+
+3. **Adds Required Tests** — For each failure mode, add the corresponding integration test to the task
+
+4. **Adds Smoke Test** — For tasks touching infrastructure, add a manual verification command
+
+**Example Analysis:**
+
+Task: "Refactor UserService to Use Repository"
+
+```
+Categories identified:
+- Persistence (uses repository)
+- Wiring/DI (factory provides repository)
+- State Machine (operation status)
+
+Failure modes to test:
+- Persistence: Not wired → Wiring test required
+- Persistence: Transaction issues → DB verification required
+- Wiring/DI: Missing injection → Wiring test required
+- State Machine: State not persisted → State persistence test required
+
+Tests to add:
+- Integration: test_user_service_has_repository()
+- Integration: test_user_persists_to_db()
+- Integration: test_status_change_persists()
+
+Smoke test:
+  If infrastructure is configured: [DB_VERIFICATION_COMMAND from project config]
+```
+
+**This step is CRITICAL.** This type of analysis catches bugs where unit tests with mocks pass, but wiring tests would fail because dependencies aren't injected correctly.
+
+---
+
+### Step 4.6: E2E Test Design
+
+**For each milestone**, Claude determines what E2E tests should validate the milestone is complete. This uses the three-agent test system.
+
+---
+
+**CRITICAL: The Agent System is MANDATORY for E2E Tests**
+
+**The Problem with Ad-Hoc E2E Tests:**
+- Ad-hoc tests (bash commands in milestone files, direct curl calls) often validate components in isolation
+- They frequently use shortcuts that don't test the real integrated platform
+- They're not saved to the catalog, so identical tests get reinvented
+- They produce false positives (test passes but feature doesn't actually work)
+
+**The Three-Agent E2E System:**
+
+| Agent | Purpose | When Used |
+|-------|---------|-----------|
+| `e2e-test-designer` | Searches catalog, finds existing tests or hands off | PLANNING: Every milestone |
+| `e2e-test-architect` | Designs new test specs, writes to catalog | PLANNING: When no existing test matches |
+| `e2e-tester` | Executes tests against real platform | EXECUTION: Final task of every milestone |
+
+**What "Real E2E" Means:**
+- Running services (not mocked)
+- Real API calls (not test fixtures)
+- Actual database state changes (not in-memory)
+- Observable outcomes (logs, API responses, DB queries)
+
+**Connection to Execution:**
+- During planning (this command): designer + architect create/find tests
+- During execution (`/ktask`): tester agent runs the tests
+- The tester MUST be invoked via `Task(subagent_type="e2e-tester", ...)`
+- NEVER run the bash commands from milestone files directly
+
+If E2E testing is configured in project config, also read `skills/shared/e2e-prompt.md` for E2E workflow instructions.
+
+---
+
+#### 4.6.1 Invoke e2e-test-designer
+
+For each milestone, send a structured request to the e2e-test-designer agent:
+
+```markdown
+## E2E Test Design Request
+
+**Milestone:** [name/number]
+**Capability:** [what user can do when complete]
+
+**Validation Requirements:**
+1. [Specific thing that must work]
+2. [Another specific thing]
+
+**Components Involved:**
+- [Component A]
+- [Component B]
+
+**Intent:** [Free-form: what we're really validating and why]
+**Expectations:** [What a passing test should demonstrate]
+```
+
+#### 4.6.2 Handle Designer Response
+
+**If designer returns existing tests:**
+- Include them in the E2E Validation section
+- Note coverage and any gaps identified
+
+**If designer returns "Architect Handoff Required":**
+- Invoke e2e-test-architect with the handoff context
+- Architect designs the test specification
+- **If reusable**: Architect writes directly to catalog (`.claude/skills/e2e-testing/tests/[category]/[name].md`)
+- **If one-off**: Architect returns spec for embedding in milestone's E2E Validation section
+- Final milestone task is "Execute E2E Test" (VALIDATION type) — not "create test file"
+
+#### 4.6.3 Incorporate into Milestone Output
+
+Add an E2E Validation section to each milestone file (see "E2E Validation Section Format" below).
+
+**Why this matters:**
+- Most milestones will match existing tests (designer handles quickly)
+- New capabilities get proper test design (architect ensures quality)
+- Every milestone has specific, actionable E2E tests — not generic "run E2E tests"
+
+---
+
+### Step 5: Review and Refine
+
+After generating all tasks, Claude presents summary:
+
+```markdown
+## Implementation Plan Summary
+
+**Total Milestones:** N
+**Total Tasks:** M
+**Estimated Effort:** [rough estimate]
+
+### Milestone Overview
+
+| Milestone | Capability | Tasks | Key Risk |
+|-----------|------------|-------|----------|
+| M1 | [capability] | X | [risk] |
+| M2 | [capability] | Y | [risk] |
+| ... | ... | ... | ... |
+
+### Architecture Consistency Check
+
+| Pattern (from Step 0) | Implemented In | Verified |
+|-----------------------|----------------|----------|
+| [Pattern 1] | Tasks X.Y, X.Z | ✅ |
+| [Pattern 2] | Tasks A.B | ✅ |
+
+### Dependencies
+
+[Any cross-milestone dependencies or external dependencies]
+
+### Open Questions
+
+[Questions that came up during planning]
+```
+
+---
+
+**Pause: Final Review**
+
+Claude asks:
+
+> "The plan is ready for review. Before we finalize:
+>
+> 1. **Architecture alignment:** Does the implementation approach match the architecture?
+>    - Patterns identified: [list]
+>    - All patterns have implementing tasks: [yes/no]
+> 2. **Task granularity:** Are tasks the right size? (Target: 1-4 hours each)
+> 3. **Missing tasks:** Anything I forgot? (Tests, migrations, documentation)
+> 4. **Risk areas:** Which milestones feel risky? Should we add spike tasks?"
+
+---
+
+### Step 6: Consistency Self-Check
+
+Before saving the plan, Claude performs a final consistency check:
+
+```markdown
+## Consistency Verification
+
+### Design → Plan Traceability
+
+For each major design decision, verify it appears in the plan:
+
+| Design Decision | Plan Reference | Status |
+|-----------------|----------------|--------|
+| [From DESIGN.md] | Task X.Y | ✅ |
+| [From DESIGN.md] | Task A.B | ✅ |
+
+### Architecture → Plan Traceability
+
+For each architectural pattern, verify implementation matches:
+
+| Architecture Says | Plan Implements | Match? |
+|-------------------|-----------------|--------|
+| "State machine with explicit transitions" | Task 1.3: Create state machine | ✅ |
+| "Events trigger transitions" | Task 1.4: Event handlers | ✅ |
+
+### Anti-Pattern Check
+
+Verify the plan does NOT include approaches ruled out in Step 0:
+
+- [ ] No [anti-pattern 1]
+- [ ] No [anti-pattern 2]
+```
+
+If any row shows a mismatch, Claude must fix the plan before proceeding.
+
+---
+
+## Task Structure
+
+Each task follows this structure for compatibility with `/ktask`:
+
+```markdown
+## Task [M.N]: [Title]
+
+**File(s):** [Specific files to create/modify]
+**Type:** CODING | RESEARCH | MIXED
+**Estimated time:** [1-4 hours]
+
+**Task Categories:** [List categories that apply — see Appendix]
+
+**Description:**
+[What this task accomplishes — be specific about behavior, not just "implement X"]
+
+**Implementation Notes:**
+[Specific guidance, patterns to follow, gotchas to avoid]
+
+**Testing Requirements:**
+
+*Unit Tests:*
+- [ ] [Specific test case 1]
+- [ ] [Specific test case 2]
+- [ ] Edge case: [description]
+- [ ] Error case: [description]
+
+*Integration Tests (based on categories):*
+[For each category that applies, list required integration tests from Step 4.5 analysis]
+- [ ] [Wiring test if Persistence/DI category]
+- [ ] [DB verification if Persistence category]
+- [ ] [State persistence if State Machine category]
+- [ ] [Contract test if Cross-Component category]
+- [ ] [Lifecycle test if Background/Async category]
+
+*Smoke Test:*
+```bash
+# Command to manually verify after implementation
+[smoke test command based on category]
+```
+
+**Acceptance Criteria:**
+- [ ] [Functional criterion 1]
+- [ ] [Functional criterion 2]
+- [ ] Unit tests written and passing
+- [ ] Integration tests written and passing
+- [ ] Smoke test verified manually
+- [ ] Code follows existing patterns in [reference file]
+
+**Branch Strategy:** [If different from milestone branch]
+```
+
+---
+
+## Task Quality Requirements
+
+Every task must be **implementable by someone who only reads that task**. Check each task against:
+
+### Specificity Checklist
+
+| Requirement | Bad Example | Good Example |
+|-------------|-------------|--------------|
+| **Files named** | "Update the service" | "Modify `src/services/user.py`" |
+| **Behavior described** | "Add validation" | "Validate symbol exists in cache before starting download" |
+| **Tests specified** | "Add tests" | "Test: returns 404 if symbol not found" |
+| **Patterns referenced** | "Follow existing patterns" | "Follow pattern in `UserService.create()`" |
+
+### Testing Requirement by Task Type
+
+| Task Type | Required Tests |
+|-----------|----------------|
+| New endpoint | Unit test for handler, integration test for request/response |
+| New service method | Unit test with mocked dependencies, happy path + error cases |
+| New model/schema | Unit test for validation, serialization |
+| Bug fix | Regression test that fails before fix, passes after |
+| Refactor | Existing tests still pass, no new tests needed |
+
+### Red Flags in Tasks
+
+- "Implement X" with no file specified
+- "Add appropriate tests" with no specifics
+- Acceptance criteria that can't be verified programmatically
+- Task depends on decisions not yet made
+- Task estimated at >4 hours (split it)
+
+---
+
+## Patterns for Common Features
+
+### Pattern: Async Operation
+
+```
+M1: User can trigger operation (returns ID immediately)
+    - Operation model (id, status, created_at)
+    - Service.create()
+    - POST endpoint
+    - E2E: trigger returns ID
+
+M2: User can check status
+    - Add progress fields
+    - Service.get_status()
+    - GET endpoint
+    - E2E: status returns progress
+
+M3: User can cancel
+    - Add cancelled state
+    - Service.cancel()
+    - DELETE endpoint
+    - Background task checks cancellation
+    - E2E: cancel stops operation
+
+M4: User sees results
+    - Add result fields
+    - Result storage
+    - E2E: completed operation has results
+```
+
+### Pattern: State Machine
+
+```
+M1: Entity in initial state
+    - Model with state field
+    - Service.create()
+    - E2E: create returns entity in initial state
+
+M2: Happy path transition
+    - State transition logic
+    - Service.transition()
+    - E2E: entity moves through states
+
+M3: Validation
+    - Invalid transition handling
+    - E2E: invalid transitions rejected
+
+M4: Failure states
+    - Error state handling
+    - Recovery logic
+    - E2E: failures handled gracefully
+```
+
+### Pattern: External Integration
+
+```
+M1: Connection health
+    - Client class
+    - Health check method
+    - E2E: health returns OK
+
+M2: Fetch data
+    - Fetch method
+    - Response parsing
+    - E2E: data retrieved correctly
+
+M3: Error handling
+    - Retry logic
+    - Error mapping
+    - E2E: errors handled gracefully
+
+M4: Caching
+    - Cache layer
+    - Invalidation
+    - E2E: cache works correctly
+```
+
+---
+
+## Red Flags
+
+Watch for these during planning:
+
+### Structure Issues
+
+| Red Flag | Problem | Fix |
+|----------|---------|-----|
+| M1 has 10+ tasks | Foundation too big | Find smaller first proof |
+| No E2E test in milestone | Can't verify | Every milestone needs E2E |
+| "Implement X" without file | Too vague | Specify exact files |
+| Task depends on unwritten task | Order wrong | Reorder or merge |
+| All model tasks, then all service tasks | Horizontal! | Restructure vertically |
+
+### Architecture Drift (Critical!)
+
+| Red Flag | Problem | Fix |
+|----------|---------|-----|
+| Architecture says "state machine" but plan uses "polling loop" | Implementation won't match design | Re-read architecture, fix task descriptions |
+| Architecture says "event-driven" but plan uses "request/response" | Wrong pattern | Redesign task to use correct pattern |
+| Code sketch doesn't match architectural diagram | Visual mismatch = real mismatch | Align code with architecture |
+| Task introduces pattern not in architecture | Scope creep or drift | Either update architecture or remove from plan |
+| "Similar to X" without checking X matches architecture | Copying wrong patterns | Verify X follows architecture before referencing |
+
+### Common Architecture Drift Examples
+
+**State Machine Drift:**
+- Architecture: "Explicit state transitions triggered by events"
+- Wrong: `while True: poll_status(); advance_if_ready()`
+- Right: `on_event(event): transition_to(next_state)`
+
+**Worker Pattern Drift:**
+- Architecture: "Workers are independent, communicate via messages"
+- Wrong: `worker.run()` returns result directly to caller
+- Right: `worker.run()` posts result to queue/event system
+
+**Async Pattern Drift:**
+- Architecture: "Non-blocking operations with callbacks"
+- Wrong: `result = await blocking_operation(); process(result)`
+- Right: `start_operation(); # later: on_complete(result)`
+
+---
+
+## Output Files
+
+**One file per milestone.** This keeps context manageable — when implementing Milestone 3, you don't need Milestones 1-2 in context.
+
+Implementation plans live in an `implementation/` subfolder next to the design documents:
+
+```
+docs/designs/[feature-name]/
+  DESIGN.md             # From /kdesign
+  ARCHITECTURE.md       # From /kdesign
+  SCENARIOS.md          # From /kdesign-validate
+  implementation/       # From this command
+    OVERVIEW.md         # Summary, dependency graph, milestone index
+    M1_[name].md        # Milestone 1: tasks, E2E test, checklist
+    M2_[name].md        # Milestone 2: tasks, E2E test, checklist
+    M3_[name].md        # Milestone 3: ...
+    ...
+```
+
+This keeps all artifacts for a feature together and makes the relationship clear.
+
+### OVERVIEW.md Contents
+
+```markdown
+# [Feature] Implementation Plan
+
+## Milestone Summary
+
+| # | Name | Tasks | E2E Test | Status |
+|---|------|-------|----------|--------|
+| M1 | [name] | N | [brief description] | ⏳ |
+| M2 | [name] | N | [brief description] | ⏳ |
+
+## Dependency Graph
+
+M1 → M2 → M3
+       ↘ M4
+
+## Reference Documents
+
+- Design: [link]
+- Architecture: [link]
+- Validation: [link]
+```
+
+### Per-Milestone File Contents
+
+Each `M[N]_[name].md` file contains:
+
+1. **Frontmatter** — References to design/architecture docs (from command params)
+2. **Milestone goal** — One sentence
+3. **E2E Validation section** — Tests from designer/architect (see format below)
+4. **Tasks** — Detailed task specs
+5. **Completion checklist** — All gates that must pass
+
+**Frontmatter format:**
+
+```markdown
+---
+design: <path from design: param>
+architecture: <path from arch: param>
+---
+
+# Milestone 1: [Name]
+...
+```
+
+The frontmatter embeds the same paths provided to this command, enabling `/ktask` to automatically discover context documents. This makes milestone files self-contained.
+
+This structure means `/ktask` only loads the milestone file it needs.
+
+### E2E Validation Section Format
+
+This section is populated by invoking the e2e-test-designer agent (Step 4.6):
+
+````markdown
+## E2E Validation
+
+### Tests to Run
+
+| Test | Purpose | Source |
+|------|---------|--------|
+| feature/smoke | Verify feature completes | Existing |
+| feature/progress | Verify progress updates | New (architect) |
+
+### Coverage Notes
+
+[From designer output: what's covered, any gaps]
+
+### New Test Specification (if architect was invoked)
+
+If the designer handed off to the architect, include the full specification here:
+
+#### Test: [category]/[name]
+
+**Purpose:** [one sentence]
+**Duration:** [expected time]
+
+**Execution Steps:**
+
+| Step | Action | Expected Result | Evidence |
+|------|--------|-----------------|----------|
+| 1 | [action] | [result] | [capture] |
+
+**Success Criteria:**
+- [ ] [Specific, measurable criterion]
+
+**Sanity Checks:**
+
+| Check | Threshold | Failure Indicates |
+|-------|-----------|-------------------|
+| [metric] | [condition] | [meaning] |
+
+---
+
+### Final Validation Task
+
+The last task in every milestone is an **Execute E2E Test** task with type VALIDATION:
+
+```markdown
+## Task N.X: Execute E2E Test
+
+**Type:** VALIDATION
+**Estimated time:** 5-15 min
+
+**Description:**
+Validate the milestone is complete using the E2E agent workflow.
+
+**MANDATORY: Use the E2E Agent System**
+
+This task MUST be executed using the e2e agent workflow:
+1. First invoke `e2e-test-designer` to find/confirm the test
+2. If new test needed, invoke `e2e-test-architect` to design it
+3. Then invoke `e2e-tester` to execute the test
+
+NEVER run bash commands from this file directly. The agents ensure:
+- Tests run against the real platform (services running)
+- Proper preflight checks validate system state
+- Results include evidence (logs, API responses, screenshots)
+- Reusable tests are saved to the catalog
+
+**Acceptance Criteria:**
+- [ ] E2E test passes (all success criteria met)
+- [ ] No regressions in existing functionality
+- [ ] Test executed via e2e-tester agent (not ad-hoc commands)
+```
+
+**Note:** The architect either wrote the test to the catalog (reusable) or embedded the spec above (one-off). Either way, the final task is execution via the agent, not running commands directly.
+````
+
+---
+
+## Integration with Other Commands
+
+**Flow:**
+1. `/kdesign-validate` → Validates design, produces scenarios and milestone structure
+2. `/kdesign-impl-plan` → Expands milestones into detailed tasks (this command)
+   - Invokes `e2e-test-designer` (haiku) per milestone to find relevant tests
+   - If no match, invokes `e2e-test-architect` (opus) to design new tests
+3. `/ktask` → Executes individual tasks with TDD
+4. `e2e-tester` → Executes E2E tests at milestone completion
+
+The validation output (scenarios, decisions, milestone structure) feeds directly into implementation planning. If validation was done, reference it to maintain consistency.
+
+**Agent integration (E2E Test System):**
+- `e2e-test-designer` (haiku, fast): Searches test catalog, returns matches or handoffs to architect — used during PLANNING
+- `e2e-test-architect` (opus, thorough): Designs new tests with steps, criteria, sanity checks — used during PLANNING
+- `e2e-tester` (opus): Executes tests against real platform with preflight checks — used during EXECUTION (`/ktask` VALIDATION tasks)
+
+**CRITICAL:** The tester agent MUST be invoked for VALIDATION tasks. Running bash commands directly is an anti-pattern that produces false positives.
+
+---
+
+## Appendix: Task Type Categories
+
+When generating tasks, classify each by type to determine required integration/smoke tests. This systematic approach prevents "components work but aren't connected" bugs.
+
+### Category Identification
+
+| Category | Indicators in Task Description |
+|----------|-------------------------------|
+| **Persistence** | DB, repository, store, save, table, migration |
+| **Wiring/DI** | Factory, inject, singleton, `get_X_service()` |
+| **State Machine** | Status, state, transition, phase, workflow |
+| **Cross-Component** | Calls, integrates, sends to, receives from |
+| **Background/Async** | Background task, worker, queue, async loop |
+| **External** | Third-party API, gateway, external service |
+| **Configuration** | Env var, config, setting, flag |
+| **API Endpoint** | Endpoint, route, request, response |
+
+Tasks often belong to multiple categories. Apply tests for all that match.
+
+### Failure Modes by Category
+
+| Category | Key Failure Modes |
+|----------|-------------------|
+| **Persistence** | Not wired, wrong connection, transaction issues, schema mismatch |
+| **Wiring/DI** | Missing injection, wrong type, stale singleton |
+| **State Machine** | Missing transition, invalid transition allowed, state not persisted |
+| **Cross-Component** | Contract mismatch, timing issues, error not propagated |
+| **Background/Async** | Never starts, never stops, orphaned work, race conditions |
+| **External** | Connection failure, auth failure, parsing errors, timeout handling |
+| **Configuration** | Missing required, wrong type, invalid value |
+| **API Endpoint** | Missing validation, wrong status code, state not actually changed |
+
+### Required Tests by Failure Mode
+
+| Failure Mode | Test Type | Pattern |
+|--------------|-----------|---------|
+| Not wired | Wiring test | `assert get_{service}()._{dependency} is not None` |
+| Missing transition | State coverage | Parameterized test for all valid transitions |
+| Contract mismatch | Contract test | Capture and verify data between components |
+| Never starts | Lifecycle test | `assert {task} is not None and not {task}.done()` |
+| Connection failure | Connection test | Health check + error handling |
+| Missing validation | Validation test | Test that endpoint returns 422 for invalid input |
+| State not changed | DB verification | Query table directly after operation |
+
+### Smoke Test Patterns
+
+| Category | Smoke Test Pattern |
+|----------|-------------------|
+| Persistence | If infrastructure is configured: [DB_QUERY_COMMAND from project config, e.g. `SELECT * FROM {table_name} LIMIT 1`] |
+| Wiring/DI | Python: `get_{service_name}()._{dependency_name} is not None` |
+| Background | If infrastructure is configured: [INFRA_LOGS_COMMAND from project config, e.g. grep for `{task_log_message}`] |
+| Configuration | `env \| grep {ENV_VAR_NAME}` |
+| API Endpoint | `curl -X {method} {endpoint}` then verify DB state |

--- a/skills/kdesign-validate/SKILL.md
+++ b/skills/kdesign-validate/SKILL.md
@@ -1,10 +1,578 @@
 ---
 name: kdesign-validate
-description: Validate design documents through scenario tracing, gap analysis, and interface contract verification.
+description: Validate design documents through scenario tracing, gap analysis, and interface contracts before implementation. Use after design is complete.
 metadata:
   version: "0.1.0"
 ---
 
 # Design Validation Command
 
-Stub — full implementation in M2.
+## Purpose
+
+Validate a design by walking through concrete scenarios before implementation begins. This catches architectural gaps, state machine inconsistencies, and integration issues *before* code is written.
+
+**When to use:** After design and architecture docs are "complete" but before writing the implementation plan.
+
+**What it produces:**
+- Validated scenarios with traced execution paths
+- Identified gaps and open questions requiring resolution
+- Interface contracts (signatures, data shapes, state transitions)
+- Vertical milestone structure for implementation
+
+---
+
+## Configuration Loading
+
+**FIRST STEP — Do this before any workflow action.**
+
+1. Read `.devops-ai/project.md` from the project root
+2. If the file exists, extract:
+   - **Project.name** — used in document headers and context
+   - **Paths.design_documents** — where design docs are stored
+3. If the file does NOT exist:
+   - Ask: "Where do you store design documents?" (default: `docs/designs/`)
+   - Ask: "What's the project name?"
+   - Proceed with answers. Suggest creating config for future sessions.
+4. Use the configured values throughout this workflow
+
+---
+
+## This is a Conversation, Not a Report
+
+**The command produces scaffolding. The value comes from the conversation.**
+
+Claude will systematically enumerate scenarios and trace through them, but:
+
+- **Claude will miss scenarios.** The most insidious bugs come from scenarios Claude doesn't think of — infrastructure failures, race conditions, recovery flows. You add these.
+- **Claude will miss context.** You know what failed before, what's flaky in the codebase, what "feels wrong." This context is essential.
+- **Gaps require decisions.** Claude identifies options and trade-offs. You decide.
+
+The command pauses for conversation at each step. Claude asks questions, proposes scenarios, and waits for feedback before proceeding. This back-and-forth is how the validation works.
+
+---
+
+## How We Work Together
+
+This is a collaborative validation, not a rubber stamp. You bring domain knowledge and intuition about what matters. Claude brings systematic scenario analysis and fresh eyes on gaps. Together we stress-test the design before committing to implementation.
+
+**On finding gaps:** These are valuable discoveries, not failures. Every gap found now is hours saved later.
+
+**On ambiguity:** When the design is ambiguous, Claude surfaces the ambiguity with options. You decide.
+
+**On scope:** We validate what's in scope for the current implementation, not the full north star vision.
+
+**On pushing back:** If Claude's scenarios seem shallow or miss the point, say so. The best gaps often come from "what about when X happens?" questions that Claude didn't consider.
+
+---
+
+## Command Usage
+
+```
+/kdesign-validate design: <design-doc.md> arch: <architecture-doc.md> [scope: <scope-description>]
+```
+
+**Required:**
+- `design:` — The design/spec document
+- `arch:` — The architecture document
+
+**Optional:**
+- `scope:` — What subset of the design to validate (e.g., "MVP Phase 1-2" or "core workflow only")
+- Additional reference docs can be included
+
+---
+
+## Validation Process
+
+### Step 1: Scenario Enumeration
+
+Claude reads the design and architecture docs, then proposes 8-12 concrete scenarios covering:
+
+**Happy paths (3-4 scenarios):**
+- The primary use case working end-to-end
+- Key variations (different inputs, configurations)
+
+**Error paths (2-3 scenarios):**
+- Expected failures (validation errors, gate failures)
+- Recovery flows (retry, resume, rollback)
+
+**Edge cases (2-3 scenarios):**
+- Cancellation at various points
+- Concurrent operations
+- State transitions that might be ambiguous
+
+**Integration boundaries (1-2 scenarios):**
+- Cross-component communication
+- External system interactions
+
+**Output format:**
+```markdown
+## Proposed Scenarios
+
+### Happy Paths
+1. **[Scenario Name]**: [One sentence description]
+2. ...
+
+### Error Paths
+3. **[Scenario Name]**: [One sentence description]
+4. ...
+
+### Edge Cases
+5. **[Scenario Name]**: [One sentence description]
+6. ...
+
+### Integration Boundaries
+7. **[Scenario Name]**: [One sentence description]
+8. ...
+```
+
+---
+
+**Pause: Scenario Review**
+
+After proposing scenarios, Claude pauses and asks:
+
+> "These are my proposed scenarios. Before I trace through them:
+>
+> 1. **What's missing?** What failure modes have you seen before? What keeps you up at night about this design?
+> 2. **What's not worth tracing?** Any scenarios here that are obvious or low-risk?
+> 3. **What's the scary scenario?** The one that feels like it could bite us — even if you can't articulate exactly why?
+>
+> I'd rather trace 5 scenarios that matter than 12 that don't."
+
+The scenarios you add here are often the most valuable ones — they come from lived experience with the codebase and past failures. This is where Claude's systematic approach meets your institutional knowledge.
+
+---
+
+### Step 2: Scenario Walk-Through
+
+For each approved scenario, Claude traces through the architecture step-by-step:
+
+**For each step:**
+- Which component handles this?
+- What is the input (data shape, state)?
+- What processing occurs?
+- What is the output (data shape, state change)?
+- What could go wrong?
+
+**Output format:**
+```markdown
+## Scenario: [Name]
+
+**Trigger:** [What initiates this scenario]
+**Expected Outcome:** [What success looks like]
+
+### Execution Trace
+
+| Step | Component | Action | Input | Output | State Change | Verification |
+|------|-----------|--------|-------|--------|--------------|--------------|
+| 1 | [Component] | [Action] | [Input] | [Output] | [State change] | [Test type needed] |
+| 2 | ... | ... | ... | ... | ... | ... |
+
+### Questions / Gaps Identified
+
+- **[Q1]**: [Question about ambiguity or missing detail]
+- **[GAP]**: [Something the design doesn't cover]
+- **[VERIFY]**: [Verification approach needed for this component type]
+```
+
+The **Verification** column surfaces test requirements during design validation, not during implementation. For each step, ask:
+- Does this component store data? → DB verification needed
+- Does this use dependency injection? → Wiring test needed
+- Is this a background task? → Lifecycle test needed
+
+**Key questions Claude asks during walk-through:**
+- "What happens if this fails?" (for each step)
+- "What state is the system in if we stop here?"
+- "How does component A know about state change in component B?"
+- "Is this synchronous or async? What are the implications?"
+
+---
+
+### Step 3: Gap Analysis
+
+After all scenarios are traced, Claude consolidates findings:
+
+**Gap Categories:**
+
+1. **State Machine Gaps** — Transitions not covered
+   - "What state is the entity in after step A completes but before step B starts?"
+   - "Can this entity be cancelled while in QUEUED state?"
+
+2. **Error Handling Gaps** — Failures without defined behavior
+   - "What happens if the write succeeds but the DB insert fails?"
+   - "How does the system recover from a partial save?"
+
+3. **Data Shape Gaps** — Undefined or ambiguous data
+   - "What fields are in the metadata JSON?"
+   - "What's the format of the result summary?"
+
+4. **Integration Gaps** — Unclear component boundaries
+   - "Who owns the decision to retry vs. fail?"
+   - "How does component B know which state to load?"
+
+5. **Concurrency Gaps** — Race conditions or ordering issues
+   - "What if two operations fire simultaneously?"
+   - "Can a cancel arrive while a save is being written?"
+
+6. **Infrastructure Gaps** — Deployment, restart, recovery issues
+   - "What happens on service restart mid-operation?"
+   - "How are orphaned operations cleaned up?"
+
+7. **Verification Gaps** — Missing integration/smoke tests for component types
+   - "This component stores data but no DB verification is specified"
+   - "This component uses DI but no wiring test is specified"
+   - "This component runs async but no lifecycle test is specified"
+
+**Output format:**
+```markdown
+## Gap Analysis
+
+### Critical (Must Resolve Before Implementation)
+
+**[GAP-1]: [Title]**
+- **Category:** State Machine
+- **Scenario:** [Which scenario exposed this]
+- **Issue:** [Description]
+- **Options:**
+  - A) [Option with trade-offs]
+  - B) [Option with trade-offs]
+- **Recommendation:** [Claude's suggestion]
+
+### Important (Should Resolve, May Defer)
+
+**[GAP-2]: [Title]**
+...
+
+### Minor (Note for Implementation)
+
+**[GAP-3]: [Title]**
+...
+```
+
+---
+
+**Pause: Gap Resolution**
+
+After presenting gaps, Claude works through each critical gap:
+
+> "I found [N] critical gaps that need decisions before we proceed.
+>
+> Let's work through them one at a time:
+>
+> **[GAP-1]: [Title]**
+> [Explanation of the issue]
+>
+> Options:
+> - A) [Option] — [Trade-offs]
+> - B) [Option] — [Trade-offs]
+>
+> I'm leaning toward [X] because [reasoning]. What's your take?
+>
+> Also — does this gap remind you of anything that's bitten you before?"
+
+**For each critical gap:**
+- Claude presents options and trade-offs
+- Claude gives a recommendation with reasoning
+- You decide (or ask for more analysis)
+- Decision is recorded
+
+This is where the real value happens. The gap analysis is just setup for the conversation. Your decisions turn vague gaps into concrete constraints.
+
+---
+
+### Step 4: Interface Contracts
+
+Based on the scenario traces and gap resolutions, Claude produces concrete interface specifications:
+
+**API Endpoints** (if applicable):
+```markdown
+### POST /resource/action
+
+**Request:**
+```json
+{
+  "field": "value"
+}
+```
+
+**Response (202 Accepted):**
+```json
+{
+  "id": "...",
+  "status": "started"
+}
+```
+
+**Error Responses:**
+- 409 Conflict: [condition]
+- 503 Service Unavailable: [condition]
+```
+
+**State Transitions** (if applicable):
+```markdown
+### Entity State Machine
+
+```
+INITIAL
+  ├─[trigger: start]─→ PROCESSING
+
+PROCESSING
+  ├─[event: complete, gate: PASS]─→ NEXT_PHASE
+  ├─[event: complete, gate: FAIL]─→ INITIAL (outcome: FAILED_GATE)
+  ├─[event: error]─→ INITIAL (outcome: FAILED)
+  ├─[event: cancelled]─→ INITIAL (outcome: CANCELLED)
+...
+```
+```
+
+**Data Shapes** (if applicable):
+```markdown
+### EntityData
+
+```python
+@dataclass
+class EntityData:
+    id: str
+    type: Literal["type_a", "type_b"]
+    created_at: datetime
+    # ... fields discovered during validation
+```
+```
+
+---
+
+### Step 5: Vertical Milestone Structure
+
+Finally, Claude proposes an implementation structure organized as vertical slices, not horizontal layers.
+
+**Principles:**
+- Each milestone is E2E testable
+- Each milestone builds on the previous
+- Each milestone delivers user-visible value (or proves a critical path)
+
+**Output format:**
+```markdown
+## Implementation Milestones
+
+### Milestone 1: [Name] — [What's E2E Testable]
+
+**User Story:** As a [user], I can [action] and see [result].
+
+**Scope:**
+- [Component A]: [What's built]
+- [Component B]: [What's built]
+- [Component C]: [Minimal/stub if needed]
+
+**E2E Test:**
+```
+Given: [Initial state]
+When: [User action]
+Then: [Observable result]
+```
+
+**Estimated Effort:** [X days]
+
+**Depends On:** [Previous milestone or nothing]
+
+---
+
+### Milestone 2: [Name] — [What's E2E Testable]
+...
+```
+
+**Example transformation (from horizontal to vertical):**
+
+Horizontal (problematic):
+```
+Phase 1: All database tables
+Phase 2: All service layer code
+Phase 3: All API endpoints
+Phase 4: Integration testing
+```
+
+Vertical (better):
+```
+Milestone 1: "User can trigger action and see result saved"
+  - DB: primary table only
+  - Service: core service (minimal)
+  - API: trigger endpoint, status endpoint
+  - E2E: Trigger → process completes → result exists
+
+Milestone 2: "User can see progress during processing"
+  - DB: Add progress columns
+  - Service: Progress tracking
+  - API: No changes (status already shows progress)
+  - E2E: Trigger → progress visible → completes
+
+Milestone 3: "User can see full workflow complete"
+  - DB: Add remaining columns
+  - Service: Full pipeline integration
+  - API: No changes
+  - E2E: Trigger → full pipeline → assessment
+```
+
+---
+
+## Final Output
+
+At the end of validation, Claude produces a summary document:
+
+```markdown
+# Design Validation: [Project Name]
+
+**Date:** [Date]
+**Documents Validated:**
+- Design: [filename]
+- Architecture: [filename]
+- Scope: [what was validated]
+
+## Validation Summary
+
+**Scenarios Validated:** X/Y passed
+**Critical Gaps Found:** N (all resolved)
+**Interface Contracts:** Defined for [list]
+
+## Key Decisions Made
+
+These decisions came from our conversation and should inform implementation:
+
+1. **[Decision]**: [What was decided and why]
+   - Context: [What gap or question prompted this]
+   - Trade-off accepted: [What we're giving up]
+
+2. ...
+
+## Scenarios Added by User
+
+These scenarios weren't in the initial enumeration but proved important:
+
+1. **[Scenario]**: [Why it mattered]
+2. ...
+
+## Remaining Open Questions
+
+To be resolved during implementation:
+
+1. **[Question]**: [Context]
+2. ...
+
+## Recommended Milestone Structure
+
+[Summary of milestones with effort estimates]
+
+## Appendix
+
+- Full scenario traces (for reference)
+- Complete interface contracts
+- Gap analysis details
+```
+
+### What Gets Saved
+
+**Save to repo (scenarios.md):**
+- Final scenario list (including user's additions)
+- Key decisions with rationale
+- Interface contracts
+- Milestone structure
+
+**Don't save (conversation artifacts):**
+- Gap analysis details (gaps are resolved, decisions captured above)
+- Walk-through traces (working material)
+- Back-and-forth discussion
+
+The saved artifact should be useful for:
+- Future sessions ("why did we decide X?")
+- Onboarding ("what is this system supposed to do?")
+- Testing ("what scenarios should we cover?")
+
+---
+
+## When Validation Fails
+
+Sometimes validation reveals that the design needs significant rework. Signs of this:
+
+- **More than 5 critical gaps** — The design is underspecified
+- **Scenarios can't be traced** — The architecture is too vague
+- **Circular dependencies** — Components depend on each other in ways that can't be resolved
+- **Missing core capability** — A fundamental piece isn't designed
+
+In these cases, Claude should say:
+
+> "This design has [N] critical gaps that suggest it needs another iteration before implementation planning. The main issues are [X, Y, Z]. I recommend we [specific action] before proceeding."
+
+This is valuable! It's much better to discover this now than after writing code.
+
+---
+
+## Conversation Patterns That Work
+
+Based on experience, these conversation patterns produce the best results:
+
+### Pattern 1: "What keeps you up at night?"
+
+After proposing scenarios, ask what feels risky even if it's hard to articulate. The answer often reveals scenarios Claude would never think of.
+
+### Pattern 2: "What's the constraint?"
+
+When a gap has multiple options, ask for the real constraint. The answer often simplifies the decision dramatically.
+
+**Example:**
+> Claude: "We could persist operations to DB, or add startup cleanup, or..."
+> User: "I'm comfortable losing state on restart. I just don't want inconsistencies."
+> Claude: [Now knows the constraint is consistency, not durability — changes the analysis]
+
+### Pattern 3: "Does this remind you of anything?"
+
+Past failures are the best predictor of future failures. When a gap surfaces, ask if it's familiar.
+
+### Pattern 4: "Let me trace that"
+
+When the user adds a scenario, trace it immediately even if it seems simple. The act of tracing often reveals surprises.
+
+### Pattern 5: "What would you need to see?"
+
+When the user is uncertain about a decision, ask what information would help.
+
+**Example:**
+> User: "I'm not sure if we need operation persistence..."
+> Claude: "What would you need to see to decide? Should I trace what happens without it?"
+> User: "Yes, show me the failure mode"
+> Claude: [Traces, shows concrete problem, user decides]
+
+---
+
+## Integration with Implementation Planning
+
+After validation completes, the milestone structure becomes the input to implementation planning. Each milestone can be expanded into tasks:
+
+```
+Milestone 1 → Phase 1 tasks (with TDD, acceptance criteria, etc.)
+Milestone 2 → Phase 2 tasks
+...
+```
+
+The key difference: tasks within a milestone are all working toward one E2E-testable outcome, not building horizontal layers.
+
+---
+
+## Why This Works (And What Doesn't)
+
+### What makes validation effective:
+
+1. **Concrete scenarios, not abstract review** — "What happens when X" is testable. "Is the design good" is not.
+
+2. **Conversation, not checklist** — Claude's initial scenarios are scaffolding. The real value comes from your additions and decisions.
+
+3. **Traced execution, not hand-waving** — Writing out "Step 1: Component A does X, Step 2: Component B receives Y" forces precision. Gaps become obvious.
+
+4. **Decisions recorded** — "I'm comfortable losing state on restart" is a constraint that shapes everything. Without recording it, the next session won't know.
+
+### What doesn't work:
+
+1. **Running it without engagement** — If you just say "looks good" to every checkpoint, the validation is useless. The value is in the pushback.
+
+2. **Skipping scenarios to save time** — The "boring" scenarios (happy path) are quick to trace. The interesting ones (infrastructure failure) take time but find real bugs.
+
+3. **Treating gaps as failures** — Finding gaps is the point. A validation that finds nothing is suspicious.
+
+4. **Over-documenting** — The conversation matters more than the artifact. Save decisions and scenarios, not every trace.

--- a/skills/kdesign/SKILL.md
+++ b/skills/kdesign/SKILL.md
@@ -1,10 +1,456 @@
 ---
 name: kdesign
-description: Collaborative design document generation with structured conversation and iterative refinement.
+description: Generate design and architecture documents through collaborative exploration. Use when starting a new feature or system change.
 metadata:
   version: "0.1.0"
 ---
 
 # Design Generation Command
 
-Stub — full implementation in M2.
+Generate design and architecture documents for a new feature or system change through collaborative exploration.
+
+This command embodies partnership values — craftsmanship over completion, honesty over confidence, decisions made together.
+
+---
+
+## Configuration Loading
+
+**FIRST STEP — Do this before any workflow action.**
+
+1. Read `.devops-ai/project.md` from the project root
+2. If the file exists, extract:
+   - **Project.name** — used in document headers and context
+   - **Paths.design_documents** — where to save design docs (e.g., `docs/designs/`)
+3. If the file does NOT exist:
+   - Ask: "Where do you store design documents?" (default: `docs/designs/`)
+   - Ask: "What's the project name?"
+   - Proceed with answers. Suggest creating config for future sessions.
+4. Use the configured values throughout this workflow
+
+---
+
+## Command Usage
+
+```
+/kdesign feature: <description> [context: <relevant-docs>]
+```
+
+**Required:**
+- `feature:` — What you're building (can be brief, we'll explore together)
+
+**Optional:**
+- `context:` — Existing docs, code references, or constraints to consider
+- Additional reference materials as needed
+
+---
+
+## What This Produces
+
+Two documents ready for validation:
+
+1. **DESIGN.md** — The what and why
+   - Problem statement and goals
+   - User-facing behavior
+   - Key decisions and trade-offs
+   - Out of scope
+
+2. **ARCHITECTURE.md** — The how
+   - Component structure
+   - Data flow
+   - API contracts
+   - State management
+   - Error handling approach
+
+---
+
+## This is a Conversation, Not a Generator
+
+The command produces drafts. The value comes from refining them together.
+
+Claude will ask questions, propose options, and surface trade-offs. You bring domain knowledge, constraints, and preferences. The back-and-forth is how good designs emerge.
+
+---
+
+## Design Process
+
+### Step 1: Understand the Problem
+
+Before proposing solutions, Claude explores the problem space:
+
+**Questions to answer:**
+- What problem are we solving?
+- Who experiences this problem?
+- What does success look like?
+- What's the current state?
+- What constraints exist?
+
+Claude asks clarifying questions. This isn't a checklist — it's a conversation to build shared understanding.
+
+**Output:** Problem statement (2-3 sentences capturing the core issue)
+
+---
+
+**Pause: Problem Alignment**
+
+Claude shares the problem statement and asks:
+
+> "Here's my understanding of the problem:
+>
+> [Problem statement]
+>
+> Does this capture it? What am I missing or misunderstanding?"
+
+---
+
+### Step 2: Explore Solution Space
+
+Before committing to a design, explore options:
+
+**For each reasonable approach:**
+- How would it work?
+- What are the trade-offs?
+- What does it make easy? Hard?
+- What are the risks?
+
+Claude proposes 2-3 approaches with trade-offs. Not every feature needs multiple options — simple features can have an obvious best approach.
+
+---
+
+**Pause: Approach Selection**
+
+Claude presents options and asks:
+
+> "Here are the approaches I see:
+>
+> **Option A: [Name]**
+> [Brief description]
+> - Good: [benefits]
+> - Concern: [drawbacks]
+>
+> **Option B: [Name]**
+> [Brief description]
+> - Good: [benefits]
+> - Concern: [drawbacks]
+>
+> I'm leaning toward [X] because [reasoning]. What's your take?"
+
+---
+
+### Step 3: Draft Design Document
+
+Based on the selected approach, Claude drafts the design doc:
+
+```markdown
+# [Feature Name]: Design
+
+## Problem Statement
+
+[2-3 sentences from Step 1]
+
+## Goals
+
+What we're trying to achieve:
+- [Goal 1]
+- [Goal 2]
+- [Goal 3]
+
+## Non-Goals (Out of Scope)
+
+What we're explicitly not doing:
+- [Non-goal 1]
+- [Non-goal 2]
+
+## User Experience
+
+How users interact with this feature:
+
+### [Scenario 1]
+[Description of user flow]
+
+### [Scenario 2]
+[Description of user flow]
+
+## Key Decisions
+
+### [Decision 1]
+**Choice:** [What we decided]
+**Alternatives considered:** [Other options]
+**Rationale:** [Why this choice]
+
+### [Decision 2]
+...
+
+## Open Questions
+
+Issues to resolve during validation or implementation:
+- [Question 1]
+- [Question 2]
+```
+
+---
+
+**Pause: Design Review**
+
+Claude shares the draft and asks:
+
+> "Here's the design draft. Before we move to architecture:
+>
+> 1. Do the goals capture what matters?
+> 2. Are the non-goals right? Anything we should add or remove?
+> 3. Do the user scenarios cover the important cases?
+> 4. Any decisions you'd make differently?"
+
+---
+
+### Step 4: Draft Architecture Document
+
+With the design settled, Claude drafts the architecture.
+
+**Remember:** Use the Rosetta stone approach — diagrams for humans, structured tables/lists for implementation planning. See "What Makes a Good Architecture Document" below.
+
+```markdown
+# [Feature Name]: Architecture
+
+## Overview
+
+[1-2 paragraph summary of the technical approach]
+
+## Component Diagram
+
+[ASCII diagram showing major components and their relationships]
+
+### Component Relationships (Structured Summary)
+
+| Component | Type | Depends On | Used By |
+|-----------|------|------------|---------|
+| [Component 1] | [Class/Module/Service] | [Dependencies] | [Consumers] |
+| [Component 2] | ... | ... | ... |
+
+## Components
+
+### [Component 1]
+**Location:** [File/module path]
+**Purpose:** [What it does — 1-2 sentences]
+**Key behaviors:** [Bullet list of main responsibilities]
+
+**Interface** (illustrative):
+[Method signatures only — no implementations]
+
+### [Component 2]
+...
+
+## Data Flow
+
+[ASCII diagram showing how data moves through the system]
+
+**Flow Steps (Structured Summary):**
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+
+## State Management
+
+| State | Where | Lifecycle |
+|-------|-------|-----------|
+| [State 1] | [Location] | [When created, when destroyed] |
+| [State 2] | ... | ... |
+
+## Error Handling
+
+| Situation | Error Type | Message/Behavior |
+|-----------|------------|------------------|
+| [Condition 1] | [Exception] | [What happens] |
+| [Condition 2] | ... | ... |
+
+## Integration Points
+
+| Component | Current State | Change Needed |
+|-----------|---------------|---------------|
+| [Existing component 1] | [How it works now] | [What changes] |
+| [Existing component 2] | ... | ... |
+
+## Migration Considerations
+
+[Brief notes on what existing code/data needs to change — NOT a phased rollout plan. Implementation planning handles the "how to get there."]
+
+## Verification Approach
+
+| Component | How to Verify |
+|-----------|---------------|
+| [Component 1] | [Test strategy] |
+| [Component 2] | ... |
+
+## Implementation Planning Summary
+
+[Structured summary for handoff to implementation planning]
+
+### New Components to Create
+| Component | Location | Purpose |
+|-----------|----------|---------|
+
+### Existing Components to Modify
+| Component | Location | Changes Required |
+|-----------|----------|------------------|
+
+### Files to Delete (if any)
+| File | Reason |
+|------|--------|
+```
+
+---
+
+**Pause: Architecture Review**
+
+Claude shares the draft and asks:
+
+> "Here's the architecture draft. Before we finalize:
+>
+> 1. Does the component breakdown make sense?
+> 2. Any existing patterns I should align with?
+> 3. Are there integration points I'm missing?
+> 4. Any concerns about this approach?"
+
+---
+
+### Step 5: Finalize Documents
+
+After incorporating feedback, Claude produces final versions of both documents.
+
+**The documents should be:**
+- Complete enough to validate (via `/kdesign-validate`)
+- Clear about what's decided vs. open
+- Honest about trade-offs and risks
+
+---
+
+## Output Files
+
+Save documents to the configured design documents path:
+
+```
+[configured design path]/
+  [feature-name]/
+    DESIGN.md
+    ARCHITECTURE.md
+```
+
+If no design path is configured, use the project's standard documentation location or ask.
+
+---
+
+## What Makes a Good Architecture Document
+
+### Architecture vs Implementation Planning
+
+**Architecture describes the finished system** — what components exist, how they interact, where state lives, what can go wrong.
+
+**Implementation planning describes how to build it** — phases, task breakdown, ordering, dependencies.
+
+Keep them separate. The architecture doc should describe the system as it will be when complete, not the steps to get there.
+
+### The Rosetta Stone Approach
+
+Architecture docs serve two audiences with different needs:
+
+**For humans:** Diagrams clarify relationships and flows at a glance. Use ASCII diagrams for:
+- Component relationships (box-and-arrow)
+- Data/control flow sequences
+- State transitions
+
+**For LLM-based implementation planning:** Structured lists and tables are more parseable. Accompany each diagram with:
+- A table or list capturing the same relationships
+- Numbered steps for flows
+- Structured summaries for implementation planning handoff
+
+Example pattern:
+```
+[ASCII diagram showing component relationships]
+
+### Component Relationships (Structured Summary)
+
+| Component | Depends On | Used By |
+|-----------|------------|---------|
+| A         | None       | B, C    |
+| B         | A          | D       |
+```
+
+### Code in Architecture Docs
+
+**YES:**
+- Interface signatures (method names, parameters, return types)
+- Illustrative snippets (3-5 lines max) showing patterns
+
+**NO:**
+- Full method implementations
+- "Pseudocode" that could be copy-pasted as working code
+- Step-by-step implementation logic
+
+Test: If someone could copy-paste it as working code, it's too much.
+
+### Level of Detail
+
+The goal: enough detail that implementation planning can break it into tasks, not so much that you've done the implementation.
+
+Good architecture doc → someone can create a task list from it
+Over-detailed doc → someone could skip planning and just copy-paste
+
+---
+
+## Principles
+
+### Right-Sized Design
+
+Not every feature needs extensive documentation:
+
+- **Small change:** Maybe just a design doc, or even inline in the PR
+- **Medium feature:** Design + architecture docs
+- **Large system:** Extensive docs, possibly split by component
+
+Match the documentation to the complexity.
+
+### Decisions Over Description
+
+Good design docs capture **why**, not just what:
+
+- "The system uses a queue" → ❌
+- "The system uses a queue because operations can take 30+ seconds and we don't want to block the API. We chose Redis over Postgres-based queues because..." → ✅
+
+### Acknowledge Uncertainty
+
+It's fine to have open questions. Better to name them than pretend certainty:
+
+- "We'll need to determine the right batch size during implementation"
+- "The error handling for [edge case] needs more thought"
+- "This assumes [X] is true — need to verify"
+
+### Design for Validation
+
+The output should be ready for `/kdesign-validate`:
+
+- Scenarios should be concrete enough to trace
+- Components should be specific enough to identify gaps
+- State transitions should be clear enough to verify
+
+---
+
+## When Design Isn't Needed
+
+Skip formal design docs when:
+
+- The change is small and obvious
+- You're spiking to learn something
+- The implementation will be faster than the design
+
+It's okay to say "let's just build it and see."
+
+---
+
+## Next Steps
+
+After design is complete:
+
+```
+/kdesign-validate design: DESIGN.md arch: ARCHITECTURE.md
+```
+
+This validates the design through scenario traces before implementation planning.

--- a/skills/kmilestone/SKILL.md
+++ b/skills/kmilestone/SKILL.md
@@ -7,4 +7,378 @@ metadata:
 
 # Milestone Execution Command
 
-Stub — full implementation in M2.
+Executes an entire milestone by invoking `/ktask` for each task, with context compaction between tasks.
+
+---
+
+## Configuration Loading
+
+**FIRST STEP — Do this before any workflow action.**
+
+1. Read `.devops-ai/project.md` from the project root
+2. If the file exists, extract:
+   - **Project.name** — used in context and reporting
+   - **Testing.unit_tests** — command to run unit tests (used in verification)
+   - **Testing.quality_checks** — command to run quality checks (used in verification)
+   - **E2E.enabled** — whether E2E testing is configured
+3. If the file does NOT exist:
+   - Ask: "What command runs your unit tests?" (default: `pytest tests/`)
+   - Ask: "What command runs quality checks?" (default: none)
+   - Proceed with answers. Suggest creating config for future sessions.
+4. Use the configured values throughout this workflow
+
+---
+
+## Command Usage
+
+```
+/kmilestone @<milestone_file.md> [--from <task_id>]
+```
+
+**Required:**
+- `@milestone_file.md` — The milestone implementation plan (e.g., `@M4_cleanup.md`)
+
+**Optional:**
+- `--from <task_id>` — Start from specific task (default: auto-detect from handoff)
+
+---
+
+## The One Rule
+
+**kmilestone invokes ktask. ktask does the work.**
+
+You are an orchestrator. Your job is to invoke `/ktask` for each task, verify completion, and manage context. You do NOT implement tasks directly.
+
+---
+
+## Workflow
+
+### 1. Initialize
+
+Parse the milestone and determine starting point.
+
+**Actions:**
+1. Extract task list from `## Task X.Y` headings in milestone file
+2. Locate handoff file: `HANDOFF_<milestone>.md` in same directory
+3. Parse handoff for "Task X.Y Complete" sections
+4. Identify first incomplete task
+
+**Output:**
+```
+Milestone: M4 - Cleanup (6 tasks)
+Completed: 4.1, 4.2 (from handoff)
+Starting from: 4.3
+```
+
+**Initialize tracking:**
+- `e2e_tests`: List to capture E2E test results from VALIDATION tasks
+- `challenges`: List to capture challenges/solutions from each task
+
+---
+
+### 2. Execute Each Task (MANDATORY: Use ktask)
+
+For each remaining task, follow this loop:
+
+#### Step 2a: Invoke ktask (MANDATORY)
+
+**You MUST invoke ktask. NEVER implement tasks directly.**
+
+**For CODING/RESEARCH/MIXED tasks:**
+```
+/ktask impl: <milestone_file> task: <task_id>
+```
+
+**For VALIDATION tasks — include E2E reminder:**
+
+**If E2E testing is configured in project config:**
+```
+/ktask impl: <milestone_file> task: <task_id>
+
+REMINDER: This is a VALIDATION task. You MUST use the E2E agent workflow:
+e2e-test-designer → e2e-test-architect → e2e-tester
+Do NOT run bash commands directly from the milestone file.
+```
+
+**If E2E testing is NOT configured:**
+```
+/ktask impl: <milestone_file> task: <task_id>
+
+REMINDER: This is a VALIDATION task. Verify functionality through the
+project's available testing commands and manual verification steps.
+```
+
+**CRITICAL: What makes a valid VALIDATION task:**
+
+VALIDATION must test **real operational flows**, not just "does it start?":
+
+| Insufficient | Valid |
+|--------------|-------|
+| "API imports without error" | "Feature completes and produces expected output" |
+| "System starts" | "Workflow executes and produces verifiable results" |
+| "No exceptions on startup" | "Full workflow completes with verifiable output" |
+
+A validation that only checks "the code runs without crashing" will miss:
+- Save/load bugs that only appear when data flows end-to-end
+- Config mismatches between components
+- Missing dependencies only needed at runtime
+
+**If a milestone changes how components interact, the validation MUST exercise that interaction with real data.**
+
+Wait for ktask to complete fully before proceeding.
+
+#### Step 2b: Verify Completion
+
+After ktask finishes, verify:
+
+- [ ] Handoff file has new "Task X.Y Complete" section?
+- [ ] Unit tests pass? (run configured unit test command)
+- [ ] Quality checks pass? (run configured quality command, if configured)
+- [ ] Changes committed?
+
+If any check fails, ktask did not complete properly. Investigate before continuing.
+
+#### Step 2c: Capture Task Learnings
+
+After each task completes, extract and record:
+
+**For VALIDATION tasks — capture E2E test results:**
+- Test name (e.g., `cli/workflow-test`)
+- Number of steps executed
+- Result (PASSED/FAILED)
+
+**For ALL tasks — capture challenges encountered:**
+- Read the new handoff section for this task
+- Extract any challenges/gotchas mentioned and their solutions
+- Record as: `{task_id, challenge, solution}`
+
+Example challenges to look for:
+- "X didn't work because Y, so we did Z instead"
+- "Gotcha: [problem] — solution: [fix]"
+- "Task was already complete because..."
+- Any workaround or non-obvious decision
+
+#### Step 2d: Run Unit Test Quality Check (CODING tasks only)
+
+For CODING tasks, invoke the quality checker:
+
+```
+Task(
+    subagent_type="unit-test-quality-checker",
+    prompt="Check tests modified in task <task_id>: <list test files>"
+)
+```
+
+If issues found: fix and re-check (up to 2 retries).
+
+#### Step 2e: Continue to Next Task
+
+Proceed directly to the next task. Do NOT pause to ask for `/compact` between tasks.
+
+If context becomes too large during execution, you may ask the user to run `/compact` at that point.
+
+---
+
+### 3. Complete Milestone (MANDATORY OUTPUT)
+
+**YOU MUST OUTPUT THIS SECTION. DO NOT SKIP IT.**
+
+After all tasks complete, you MUST produce this summary. This is not optional — the user depends on this output for PR creation and documentation.
+
+**If you've lost track of challenges/e2e tests due to context, reconstruct them by reading the handoff file sections for each task.**
+
+```
+## Milestone Complete: M4 - Cleanup
+
+**Tasks completed:** 4.1 through 4.6
+**Quality gates:** All passed
+
+**Handoff:** docs/designs/.../HANDOFF_M4.md
+
+### E2E Tests Performed
+
+| Test | Steps | Result |
+|------|-------|--------|
+| workflow/core-test | 8 | PASSED |
+| feature/integration | 5 | PASSED |
+
+(If no VALIDATION tasks or no E2E tests run, state: "No E2E tests in this milestone")
+
+### Challenges & Solutions
+
+| Task | Challenge | Solution |
+|------|-----------|----------|
+| 4.1 | stderr not captured in test output | Used alternative output method |
+| 4.3 | Task already complete from earlier task | Added unit tests to validate existing code |
+| 4.5 | No existing E2E test in catalog | Designed new test via e2e-test-architect |
+
+(If no challenges encountered, state: "No significant challenges encountered")
+
+### Failed Tests (Not Due to This Work)
+
+List any test failures observed during the milestone that were:
+- Pre-existing (failed before your changes)
+- Flaky (passed on retry)
+- Unrelated to milestone scope
+
+| Test | Failure | Status |
+|------|---------|--------|
+| test_foo.py::test_bar | Timeout on CI | Pre-existing, not in scope |
+
+(If none, state: "All test failures were addressed")
+
+Ready for PR creation.
+```
+
+**CRITICAL: Do not say "Ready for PR creation" without outputting the tables above.**
+
+**Notes on the summary tables:**
+
+- **E2E Tests Performed**: Include ALL tests run during VALIDATION tasks. If multiple tests were run, list each one.
+- **Challenges & Solutions**: Aggregate from all tasks. Only include actual challenges (not routine work). This helps with:
+  - PR descriptions (copy directly)
+  - Future debugging (what went wrong before)
+  - Process improvement (recurring issues)
+- **Failed Tests**: Document any flaky or pre-existing failures so they don't block the PR or cause confusion during review.
+
+---
+
+## Anti-Patterns (NEVER Do These)
+
+| Anti-Pattern | Why It's Wrong | Do This Instead |
+|--------------|----------------|-----------------|
+| Implementing tasks directly | Bypasses TDD, handoffs, quality gates | Invoke `/ktask` |
+| Running E2E bash commands manually | Skips e2e-tester agent validation | Include E2E reminder when invoking ktask for VALIDATION tasks |
+| Skipping handoff verification | Next task loses context | Always verify handoff updated |
+| Batching multiple tasks | Loses per-task verification | One ktask invocation per task |
+| Accepting "files don't exist" without verification | Research errors get hidden | See Guardrail section below |
+
+---
+
+## Guardrail: Unexpected Findings
+
+If ktask reports something that contradicts task assumptions, **do not proceed blindly**.
+
+Examples of unexpected findings:
+- "Files mentioned in task don't exist"
+- "Pattern not found in codebase"
+- "Code is already fixed / task already complete"
+- Anything else that seems odd during research or implementation
+
+**When this happens:**
+
+1. **Ask ktask to double-check** with alternative search methods
+2. **If still unexpected, escalate to user**: "Task 4.1 references 8 files but I only found 4. Should I proceed with what exists, or is something wrong?"
+
+Research errors are dangerous because they're silent. A wrong conclusion ("files don't exist") leads to skipped work or wrong implementations. Always verify unexpected findings before proceeding.
+
+---
+
+## Resume Behavior
+
+kmilestone is idempotent. Running it again:
+
+1. Parses handoff file
+2. Finds completed tasks
+3. Resumes from first incomplete task
+
+**Force restart:** `--from 4.1` ignores handoff and starts fresh.
+
+---
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| ktask fails quality gates | ktask handles retry internally |
+| ktask reports blocker | Stop, report to user, await guidance |
+| Handoff not updated after ktask | Error — ktask did not complete. Investigate. |
+| ktask reports unexpected finding | Double-check, then escalate to user if still odd |
+| Context becomes too large | Ask user to run `/compact`, then continue |
+
+---
+
+## Quick Reference
+
+| Phase | Action | Output |
+|-------|--------|--------|
+| **Initialize** | Parse milestone + handoff | "Starting from: X.Y" |
+| **Per-task** | `/ktask impl: <file> task: <id>` | ktask completes task |
+| **VALIDATION task** | Include E2E reminder in ktask invocation | ktask uses e2e agents |
+| **Verify** | Check handoff, tests, quality | All checks pass |
+| **Capture** | Record E2E results + challenges | Update tracking lists |
+| **Quality check** | unit-test-quality-checker (CODING) | No issues found |
+| **Complete** | Report summary with tables | E2E tests + Challenges tables |
+
+---
+
+## Example Execution
+
+```
+User: /kmilestone @docs/designs/feature/implementation/M3_core.md
+
+Claude:
+Milestone: M3 - Core Implementation (5 tasks)
+Completed: 3.1 (from handoff)
+Starting from: 3.2
+
+---
+
+Invoking ktask for Task 3.2...
+
+/ktask impl: docs/designs/feature/implementation/M3_core.md task: 3.2
+
+[ktask runs full workflow: Setup → Research → TDD → Verify → Handoff]
+
+---
+
+Task 3.2 complete.
+Handoff updated
+Tests pass
+Quality checks pass
+Changes committed
+
+---
+
+Invoking ktask for Task 3.3...
+
+/ktask impl: docs/designs/feature/implementation/M3_core.md task: 3.3
+
+[... continues through 3.4 ...]
+
+---
+
+Invoking ktask for Task 3.5 (VALIDATION)...
+
+/ktask impl: docs/designs/feature/implementation/M3_core.md task: 3.5
+
+REMINDER: This is a VALIDATION task. You MUST use the E2E agent workflow:
+e2e-test-designer → e2e-test-architect → e2e-tester
+Do NOT run bash commands directly from the milestone file.
+
+[ktask uses e2e agents, reports PASS/FAIL]
+
+---
+
+## Milestone Complete: M3 - Core Implementation
+
+**Tasks completed:** 3.1 through 3.5
+**Quality gates:** All passed
+
+**Handoff:** docs/designs/feature/implementation/HANDOFF_M3.md
+
+### E2E Tests Performed
+
+| Test | Steps | Result |
+|------|-------|--------|
+| feature/core-workflow | 6 | PASSED |
+
+### Challenges & Solutions
+
+| Task | Challenge | Solution |
+|------|-----------|----------|
+| 3.2 | Import cycle between modules | Moved shared types to separate file |
+| 3.4 | Flaky test due to timing | Added retry logic with backoff |
+
+Ready for PR creation.
+```

--- a/skills/kmilestone/SKILL.md
+++ b/skills/kmilestone/SKILL.md
@@ -91,7 +91,7 @@ For each remaining task, follow this loop:
 
 **For VALIDATION tasks — include E2E reminder:**
 
-**If E2E testing is configured in project config:**
+**If E2E testing is configured in project config** (also read `skills/shared/e2e-prompt.md` for full E2E workflow):
 ```
 /ktask impl: <milestone_file> task: <task_id>
 

--- a/skills/ktask/SKILL.md
+++ b/skills/ktask/SKILL.md
@@ -7,4 +7,441 @@ metadata:
 
 # Task Implementation Command
 
-Stub — full implementation in M2.
+Implements tasks from a vertical implementation plan using TDD methodology.
+
+This command embodies partnership values — craftsmanship over completion, honesty over confidence, decisions made together.
+
+---
+
+## Configuration Loading
+
+**FIRST STEP — Do this before any workflow action.**
+
+1. Read `.devops-ai/project.md` from the project root
+2. If the file exists, extract:
+   - **Project.name** — used in context and reporting
+   - **Testing.unit_tests** — command to run unit tests (e.g., `make test-unit`, `pytest tests/unit`)
+   - **Testing.quality_checks** — command to run quality checks (e.g., `make quality`, `ruff check .`)
+   - **Infrastructure.start** — command to start infrastructure (e.g., `docker compose up -d`)
+   - **Infrastructure.logs** — command to check logs (e.g., `docker compose logs backend --since 5m`)
+   - **E2E.enabled** — whether E2E testing is configured
+3. If the file does NOT exist:
+   - Ask: "What command runs your unit tests?" (default: `pytest tests/`)
+   - Ask: "What command runs quality checks?" (default: none)
+   - Ask: "Does this project use infrastructure (Docker, databases, etc.)?" (default: no)
+   - Proceed with answers. Suggest creating config for future sessions.
+4. Use the configured values throughout this workflow
+
+---
+
+## Command Usage
+
+```
+/ktask impl: <plan.md> task: <task-id> [design: <design.md>] [arch: <architecture.md>]
+```
+
+**Required:**
+- `impl:` — Implementation plan (from `/kdesign-impl-plan`)
+- `task:` — Task ID, milestone, or range (e.g., "M1", "2.3", "Phase 2")
+
+**Optional:**
+- `design:` — Design document (overrides frontmatter)
+- `arch:` — Architecture document (overrides frontmatter)
+- Additional reference docs as needed
+
+### Context Document Resolution
+
+The command automatically discovers design/architecture docs:
+
+1. **Parse frontmatter** from the implementation plan file
+2. **If frontmatter has refs** → use them automatically
+3. **If CLI params provided** → they override frontmatter
+4. **If neither** → fail with: "No design/architecture docs found. Add frontmatter to plan or pass design:/arch: params"
+
+**Frontmatter example** (in milestone file):
+
+```markdown
+---
+design: docs/designs/feature-name/DESIGN.md
+architecture: docs/designs/feature-name/ARCHITECTURE.md
+---
+```
+
+---
+
+## Workflow Overview
+
+```
+1. Setup       → Retrieve task, verify branch, classify type
+2. Research    → Read docs, check handoffs, summarize approach
+3. Implement   → TDD cycle (CODING tasks) or E2E execution (VALIDATION tasks)
+4. Verify      → Acceptance criteria, quality gates
+5. Complete    → HANDOFF UPDATE (MANDATORY), task summary
+```
+
+**Handoff updates are MANDATORY** after every task (not just milestones).
+
+---
+
+## Code Samples Are Structure, Not Implementation
+
+**Implementation plans contain code samples. These show patterns and wiring — not complete functionality.**
+
+When you see code in a plan, your job is to:
+1. Understand the *structure* it demonstrates
+2. Read the *existing code* (if replacing something) to understand what functionality exists
+3. Implement the new structure with full functionality
+
+If the code sample looks simpler than the existing code, that's expected — the sample shows skeleton, you provide the meat.
+
+**Copying code samples verbatim is not implementation. It's transcription.**
+
+---
+
+## 1. Setup
+
+### Retrieve Task
+
+Extract the task from the implementation plan. Display:
+
+- Task title and description
+- Acceptance criteria
+- Files to create/modify (for CODING tasks)
+- E2E test reference (for VALIDATION tasks)
+
+If validation output is provided, review key decisions to ensure consistency with resolved gaps.
+
+### Verify Branch
+
+Check task description for branch instructions:
+- "Create new branch: [name]"
+- "Work on branch: [name]"
+- "Branch strategy: [description]"
+
+If no branch strategy is specified, ask before proceeding.
+
+### Classify Task Type
+
+State the classification explicitly:
+
+- **CODING** — Implementation work. TDD is required.
+- **RESEARCH** — Investigation, analysis, documentation. No TDD.
+- **MIXED** — Research first, then TDD for implementation portion.
+- **VALIDATION** — E2E test execution. Run the test, report results.
+
+### Check Handoffs
+
+Look for `HANDOFF_*.md` in the implementation plan directory. If present, read and note:
+- Critical gotchas from previous tasks
+- Emergent patterns to follow
+- Workarounds for known issues
+
+---
+
+## 2. Research Phase (All Tasks)
+
+Before writing any code:
+
+1. **Read context documents** — Design doc and architecture doc (from frontmatter or params), relevant sections of implementation plan
+2. **Read code being replaced** — If this task replaces or restructures existing code, read it first. Understand what functionality exists before you design anything.
+3. **Identify patterns to follow** — Find similar code in the codebase for style and conventions
+4. **Locate dependencies** — Files, classes, functions that will be involved
+5. **Note integration points** — How this task connects to other components
+
+**Output:** Brief summary (2-4 sentences) covering:
+- Design intent
+- Architecture approach
+- Implementation approach
+
+Do not write implementation code during this phase.
+
+### Guardrail: Unexpected Findings
+
+If you discover something that contradicts the task's assumptions, **stop and verify before proceeding**.
+
+Examples:
+- Files mentioned in the task don't exist
+- Patterns the task says to remove aren't found
+- Code appears to already be fixed
+- Search returns unexpected results
+- Anything that seems odd or doesn't match expectations
+
+**When this happens:**
+
+1. **Double-check with alternative methods** — Try different glob patterns, grep variations, or broader searches
+2. **If still unexpected, escalate**: Report to user/orchestrator before proceeding. Example: "Task says to fix ValueError in 8 indicator files, but I only found 4 files and none have ValueError. Should I proceed or investigate further?"
+
+**Why this matters:** Research errors are silent and dangerous. A wrong conclusion like "files don't exist" leads to skipped work. Always verify unexpected findings.
+
+---
+
+## 3. Implementation (Coding Tasks Only)
+
+Follow the TDD cycle: **RED → GREEN → REFACTOR**
+
+### RED: Write Failing Tests
+
+Before any implementation:
+
+1. Create test file(s) following project conventions
+2. Write tests covering:
+   - Happy path (normal operation)
+   - Error cases (failures, exceptions)
+   - Edge cases (boundaries, null values)
+3. Run tests using the configured unit test command
+4. Verify tests fail meaningfully (not import errors)
+
+Show output: "Tests written and failing as expected"
+
+If you catch yourself writing implementation before tests, stop, delete the implementation code, and return to this phase.
+
+### GREEN: Minimal Implementation
+
+1. Write just enough code to make tests pass
+2. Follow existing patterns in the codebase
+3. Run tests frequently during implementation
+4. Don't over-engineer or add untested features
+
+Show output: "All tests passing"
+
+### REFACTOR: Improve Quality
+
+1. Improve code clarity and maintainability
+2. Extract common patterns
+3. Add documentation and type hints
+4. Run tests after each refactoring
+5. Run quality checks if configured
+
+Show output: "Tests and quality checks passing"
+
+---
+
+## 4. Verification
+
+### Integration Smoke Test (CODING tasks)
+
+**If infrastructure is configured in project config:**
+
+Unit tests verify components in isolation. Integration tests verify they work together. Passing unit tests does not mean the system works.
+
+After unit tests pass (for changes affecting system behavior):
+
+1. **Start system** using the configured infrastructure start command
+2. **Execute modified flow**: Use CLI commands or API calls appropriate to the project
+3. **Verify end-to-end**: Does the operation complete? Is state consistent?
+4. **Check logs** using the configured infrastructure logs command
+5. **Report**: "Integration test passed" or "Issue found: [description]"
+
+**Skip integration testing for:**
+
+- Pure refactoring with no behavior change
+- Documentation-only changes
+- Test-only changes
+
+If integration test fails, investigate and fix before proceeding. The issue is likely architectural, not just code.
+
+**If infrastructure is NOT configured:** Skip this section. Unit tests and quality checks are the verification layer.
+
+### E2E Test Execution (VALIDATION tasks)
+
+**If E2E testing is configured in project config:**
+
+For tasks with type VALIDATION, this IS the implementation step.
+
+---
+
+**CRITICAL: E2E Tests MUST Use the Agent System**
+
+**NEVER** write or run ad-hoc E2E tests. **ALWAYS** use the e2e agent workflow:
+
+```
+e2e-test-designer → (finds existing OR hands off to) → e2e-test-architect → e2e-tester
+```
+
+**Why this matters:**
+- Ad-hoc tests often test components in isolation, not the real integrated system
+- Ad-hoc tests frequently use shortcuts that don't validate actual platform behavior
+- The agent system ensures tests run against the real platform with proper setup/teardown
+- The agent system produces reproducible tests saved to the catalog for future use
+
+**What "real E2E" means:**
+- Running infrastructure (not mocked services)
+- Real API calls (not unit test fixtures)
+- Actual state changes (not in-memory)
+- Observable outcomes (logs, API responses, queries)
+
+---
+
+**Mandatory Workflow:**
+
+1. **Find or design the test** — Use `e2e-test-designer` agent:
+   ```
+   Task(subagent_type="e2e-test-designer", prompt="Search for E2E tests covering [milestone capability]...")
+   ```
+   - Designer searches the catalog at `.claude/skills/e2e-testing/tests/`
+   - If match found: Returns test reference to execute
+   - If no match: Returns "Architect Handoff Required" with context
+
+2. **If new test needed** — Use `e2e-test-architect` agent:
+   ```
+   Task(subagent_type="e2e-test-architect", prompt="Design E2E test for [capability]. Context from designer: ...")
+   ```
+   - Architect designs full test specification
+   - Architect writes test to catalog (`.claude/skills/e2e-testing/tests/[category]/[name].md`)
+   - Returns test spec for execution
+
+3. **Execute the test** — Use `e2e-tester` agent:
+   ```
+   Task(subagent_type="e2e-tester", prompt="Execute E2E test: [category]/[name] ...")
+   ```
+   - Tester runs preflight checks
+   - Tester executes test steps against real platform
+   - Tester reports PASS/FAIL with evidence
+
+4. **Report results**: Document pass/fail for each success criterion
+
+5. **Fix failures**: If E2E tests fail, investigate — the issue is in previously implemented tasks
+
+**Anti-patterns (NEVER do these):**
+- Running bash commands from the milestone file directly
+- Writing Python scripts to "test" the feature
+- Using curl commands without the e2e-tester agent context
+- Calling integration tests "E2E" — they're different
+- Skipping the designer and going straight to running tests
+
+**If E2E testing is NOT configured:** VALIDATION tasks should verify functionality through the project's available testing commands and manual verification steps.
+
+### Acceptance Criteria Validation
+
+Go back to the task description. For each acceptance criterion:
+
+1. Identify the type (feature, unit test, integration test, performance, documentation)
+2. Validate it appropriately
+3. Check it off with status
+
+```markdown
+- [x] Acceptance criterion 1 — VALIDATED
+- [x] Acceptance criterion 2 — VALIDATED
+- [ ] Acceptance criterion 3 — NOT MET (needs: ...)
+```
+
+If any criterion is not met, continue working before proceeding.
+
+### Quality Gates
+
+All must pass before completion:
+
+- [ ] All unit tests pass (run configured unit test command)
+- [ ] Quality checks pass (run configured quality command, if configured)
+- [ ] E2E test passed (VALIDATION tasks, if E2E is configured)
+- [ ] Code is documented (docstrings explaining "why")
+- [ ] All work is committed with clear messages
+- [ ] No security vulnerabilities introduced
+- [ ] **Handoff document updated** (EVERY task - see Completion section)
+
+---
+
+## 5. Completion
+
+### Handoff Document (MANDATORY - DO THIS FIRST)
+
+**REQUIRED AFTER EVERY TASK**: You MUST update the handoff document before writing the task summary.
+
+**Action steps:**
+
+1. **Locate handoff file**: `HANDOFF_<phase/feature>.md` in the implementation plan directory
+   - If it doesn't exist, CREATE it
+
+2. **Add section for this task**: Add a new section titled `## Task X.Y Complete: [Task Name]`
+
+3. **Document learnings** (only if it saves time for next implementer):
+   - **Gotchas**: Problem + symptom + solution
+   - **Workarounds**: Non-obvious solutions to constraints
+   - **Emergent patterns**: Architectural decisions made during implementation
+   - **Implementation notes**: Key patterns or approaches that worked well
+
+4. **Add "Next Task Notes"**: Brief guidance for the next task (what files to import, what to watch out for)
+
+**EXCLUDE** (wastes tokens):
+- Task completion status (already in plan)
+- Process steps (already in this command)
+- Unit test counts or coverage numbers (observable from running tests)
+- File listings (observable from codebase)
+
+**INCLUDE for VALIDATION tasks:**
+- E2E test name and result (PASSED/FAILED)
+- Number of steps executed
+- Any failure details or investigation notes
+
+E2E tests are significant outcomes — they validate real system behavior, not just code correctness. Record them in the handoff so kmilestone can aggregate them into the milestone report.
+
+**Target size**: Under 100 lines total for the entire handoff file.
+
+**Why this matters**: You consistently find handoff documents useful when starting tasks. Creating them ensures the next task (even if it's you in a new session) benefits from your learnings.
+
+### Task Summary
+
+Provide a summary of what was accomplished:
+
+```markdown
+## Task Complete: [Task ID]
+
+**What was implemented:**
+- [Brief description of the change]
+
+**Files changed:**
+- [List of files created/modified/deleted]
+
+**Key decisions made:**
+- [Any non-obvious choices and why]
+
+**Issues encountered:**
+- [Problems hit and how they were resolved, or "None"]
+```
+
+This summary is displayed to the human (or orchestrator) and provides visibility into what happened during the task.
+
+**Note:** PR creation is handled at milestone level, not per-task. Commits should be made after each task, but PRs are created when the full milestone is complete.
+
+---
+
+## Error Handling
+
+If you encounter blockers:
+
+- Do not mark task as complete
+- Keep task in "doing" status
+- Document the blocker
+- Ask for guidance on how to proceed
+
+---
+
+## Task Instructions Override
+
+If task-specific instructions contradict this command, follow the task instructions. Tasks may have context that requires different approaches.
+
+---
+
+## Project-Specific Test Patterns
+
+Some projects have specific test patterns (e.g., custom test runners, fixtures that handle output formatting, framework-specific test helpers). These belong in the project's `.devops-ai/project.md` under `Project-Specific Patterns`, not in this skill.
+
+When implementing tests, check the project config for any project-specific patterns before writing test code.
+
+---
+
+## Quick Reference
+
+| Phase | Key Actions | Output |
+|-------|-------------|--------|
+| Setup | Retrieve, branch, classify, handoffs | Task details displayed |
+| Research | Read docs, find patterns | 2-4 sentence summary |
+| RED | Write tests, run, verify fail (CODING) | "Tests failing as expected" |
+| GREEN | Implement, run tests (CODING) | "All tests passing" |
+| REFACTOR | Clean up, quality checks (CODING) | "Tests and quality passing" |
+| E2E | Run milestone E2E scenario (VALIDATION) | "E2E test passed" |
+| Integration | Start system, execute flow, check logs | "Integration passed" |
+| Acceptance | Validate each criterion | Checklist with status |
+| Quality | Tests, quality, commits | All gates passed |
+| **Handoff** | **Update HANDOFF_*.md (EVERY task)** | **Section added to handoff** |
+| Summary | Write task completion summary | Task summary with changes/decisions |

--- a/skills/ktask/SKILL.md
+++ b/skills/ktask/SKILL.md
@@ -244,7 +244,7 @@ If integration test fails, investigate and fix before proceeding. The issue is l
 
 ### E2E Test Execution (VALIDATION tasks)
 
-**If E2E testing is configured in project config:**
+**If E2E testing is configured in project config**, also read `skills/shared/e2e-prompt.md` for the full E2E workflow instructions.
 
 For tasks with type VALIDATION, this IS the implementation step.
 

--- a/skills/shared/e2e-prompt.md
+++ b/skills/shared/e2e-prompt.md
@@ -1,0 +1,155 @@
+# E2E Testing Workflow
+
+This file defines the end-to-end testing workflow using the three-agent system. It is loaded conditionally by ktask and kmilestone when E2E testing is configured in the project.
+
+---
+
+## When This Applies
+
+This workflow applies when:
+- The project has E2E testing configured in `.devops-ai/project.md` (under `E2E`)
+- A task has type **VALIDATION**
+- A milestone includes a validation task
+
+If E2E testing is not configured, VALIDATION tasks should use the project's available testing commands and manual verification instead.
+
+---
+
+## The Three-Agent System
+
+E2E tests use three specialized agents, each with a distinct role:
+
+| Agent | Purpose | Model | When Used |
+|-------|---------|-------|-----------|
+| `e2e-test-designer` | Searches test catalog for existing tests, or hands off to architect | Fast (haiku) | Every validation |
+| `e2e-test-architect` | Designs new test specifications with steps, criteria, and sanity checks | Thorough (opus) | When no existing test matches |
+| `e2e-tester` | Executes tests against the real running system | Thorough (opus) | Every validation |
+
+---
+
+## Mandatory Workflow
+
+### Step 1: Find or Design the Test
+
+Invoke the `e2e-test-designer` agent:
+
+```
+Task(
+    subagent_type="e2e-test-designer",
+    prompt="Search for E2E tests covering [milestone capability].
+    Validation requirements: [list what must work].
+    Components involved: [list components]."
+)
+```
+
+The designer searches the catalog at `.claude/skills/e2e-testing/tests/`.
+
+**If match found:** Designer returns the test reference. Proceed to Step 3.
+
+**If no match:** Designer returns "Architect Handoff Required" with context. Proceed to Step 2.
+
+### Step 2: Design New Test (if needed)
+
+Invoke the `e2e-test-architect` agent with the handoff context:
+
+```
+Task(
+    subagent_type="e2e-test-architect",
+    prompt="Design E2E test for [capability].
+    Context from designer: [handoff context].
+    The test should verify: [specific requirements]."
+)
+```
+
+The architect:
+- Designs the full test specification (steps, expected results, evidence to capture)
+- Defines success criteria and sanity checks
+- If the test is reusable, writes it to the catalog (`.claude/skills/e2e-testing/tests/[category]/[name].md`)
+- If the test is a one-off, returns the spec for embedding in the milestone
+
+### Step 3: Execute the Test
+
+Invoke the `e2e-tester` agent:
+
+```
+Task(
+    subagent_type="e2e-tester",
+    prompt="Execute E2E test: [category]/[name].
+    Test specification: [spec or catalog reference].
+    System should be running at: [endpoints/ports]."
+)
+```
+
+The tester:
+- Runs preflight checks (is the system running? are prerequisites met?)
+- Executes each test step against the real system
+- Captures evidence (logs, API responses, state queries)
+- Reports PASS/FAIL with evidence for each success criterion
+
+### Step 4: Report Results
+
+After execution, document:
+- Test name and category
+- Number of steps executed
+- Result (PASSED/FAILED) for each success criterion
+- Evidence captured
+- Any failures with investigation notes
+
+---
+
+## What "Real E2E" Means
+
+E2E tests must exercise the actual system, not test doubles:
+
+| Real E2E | Not E2E |
+|----------|---------|
+| Running infrastructure (containers, services) | Mocked services |
+| Real API calls to actual endpoints | Unit test fixtures |
+| Actual state changes (database, files) | In-memory state |
+| Observable outcomes (logs, responses, queries) | Assertions on mocks |
+
+---
+
+## Anti-Patterns
+
+**NEVER do these:**
+- Run bash commands from milestone files directly — use the agent workflow
+- Write Python scripts to "test" the feature — use the tester agent
+- Use curl commands without the e2e-tester agent context
+- Call integration tests "E2E" — they test different things
+- Skip the designer and go straight to running tests
+- Accept "it starts without errors" as valid E2E — must verify real operational flows
+
+---
+
+## Valid vs Invalid Validation
+
+| Invalid | Valid |
+|---------|-------|
+| "API imports without error" | "Feature completes and produces expected output" |
+| "System starts" | "Workflow executes and produces verifiable results" |
+| "No exceptions on startup" | "Full workflow completes with verifiable output" |
+
+A validation that only checks "the code runs without crashing" will miss:
+- Save/load bugs that only appear when data flows end-to-end
+- Config mismatches between components
+- Missing dependencies only needed at runtime
+
+**If a milestone changes how components interact, the validation MUST exercise that interaction with real data.**
+
+---
+
+## Integration with ktask
+
+When ktask encounters a VALIDATION task:
+1. Load this E2E prompt
+2. Follow Steps 1-4 above
+3. Record results in the handoff document
+4. Include test name, steps executed, and PASS/FAIL result
+
+## Integration with kmilestone
+
+When kmilestone encounters a VALIDATION task:
+1. Include E2E reminder when invoking ktask
+2. After ktask completes, capture E2E test results in tracking
+3. Include all E2E results in the milestone completion summary table


### PR DESCRIPTION
## Summary

- Generalize all 5 ktrdr-specific k* commands into portable, configuration-driven skills following the Agent Skills standard (agentskills.io)
- Replace all hardcoded `make test-unit`, `docker compose`, `psql`, and `ktrdr/` references with config-driven values from `.devops-ai/project.md`
- Add Configuration Loading preamble to every skill, conditional infrastructure/E2E sections, and a shared E2E prompt

## Skills Generalized

| Skill | Lines | Key Changes |
|-------|-------|-------------|
| kdesign | 456 | Frontmatter, config preamble, "Karl"→"You" |
| kdesign-validate | 578 | Removed ktrdr examples, project history |
| kdesign-impl-plan | 974 | All commands config-driven, infra/E2E conditional |
| ktask | 449 | Commands config-driven, runner fixture→generic guidance |
| kmilestone | 386 | Commands config-driven, E2E conditional |
| shared/e2e-prompt | 155 | Extracted E2E agent workflow for conditional loading |

## Verification

- All 5 skills have valid YAML frontmatter
- All 5 skills have Configuration Loading preamble referencing `.devops-ai/project.md`
- Zero ktrdr-specific commands in workflow sections
- Cross-skill references match SCENARIOS.md table
- Conditional markers consistent across all skills

## Test plan

- [x] M2 E2E validation script passes (frontmatter, config loading, no hardcoded commands, conditional sections, shared prompt exists)
- [x] Cross-skill consistency verified (Task 2.7)
- [x] All skills reference `.devops-ai/project.md`, none reference `.claude/config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)