### PR TITLE
feat(M3): graceful degradation + config generation

### DIFF
--- a/docs/designs/skill-generalization/implementation/HANDOFF_M3.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M3.md
@@ -1,0 +1,13 @@
+# M3 Handoff
+
+## Task 3.1 Complete: Add No-Config Behavior
+
+**Changes were minimal** — M2 already had reasonable no-config paths. Enhancements:
+- All 5 skills now have explicit "Would you like me to create a `.devops-ai/project.md`..." suggestion
+- ktask, kmilestone, kdesign-impl-plan now note which sections will be skipped (infra/E2E)
+- Question counts: kdesign/validate: 2, ktask/impl-plan: 3, kmilestone: 2 (all <=4)
+
+**Next Task Notes (3.2 — config generation):**
+- Add project inspection logic (pyproject.toml, package.json, Makefile, etc.)
+- Goes in the Configuration Loading section of each skill
+- Refer to `templates/project-config.md` for the template structure

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M3.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M3.md
@@ -30,6 +30,13 @@
 - kdesign-impl-plan, ktask, kmilestone: essential values asked for, optional values (Infrastructure, E2E) skipped silently with brief note
 - All 3 skills with optional values include "Do NOT offer to update the config file unless the user asks"
 
-**Next Task Notes (3.4 — verify degradation paths):**
-- Trace all 6 scenarios from the task description through all 5 skills
-- Fix any dead ends or inconsistencies found
+## Task 3.4 Complete: Verify Degradation Paths
+
+**Traced all 6 scenarios through all 5 skills** (30 traces total):
+- Scenarios 1-5 (full config, no config, partial essential, partial optional, no config + decline): All passed without gaps
+- Scenario 6 (malformed config): **GAP FOUND** — no skill handled garbled/unrecognizable config files
+
+**Fix applied:** Added malformed config handling line to step 2 of all 5 skills:
+`If the file exists but is malformed (no recognizable sections, garbled content): suggest starting from the template at templates/project-config.md and fall back to the no-config path`
+
+All 6 scenarios now pass across all 5 skills.

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M3.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M3.md
@@ -11,3 +11,14 @@
 - Add project inspection logic (pyproject.toml, package.json, Makefile, etc.)
 - Goes in the Configuration Loading section of each skill
 - Refer to `templates/project-config.md` for the template structure
+
+## Task 3.2 Complete: Add Config Generation Capability
+
+**Added "Generating Config (if user accepts)" subsection** to all 5 skills' Configuration Loading section. Same 4-step block in each: inspect project root, pre-fill, show draft, write after confirmation.
+
+**Covers:** pyproject.toml (Python), package.json (Node/TS), Makefile, go.mod (Go), Cargo.toml (Rust)
+
+**Next Task Notes (3.3 — partial config):**
+- Handle case where `.devops-ai/project.md` exists but has missing/empty sections
+- Essential vs optional values differ per skill (see SCENARIOS.md mapping)
+- "Not configured" markers in template should be treated same as missing

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M3.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M3.md
@@ -22,3 +22,14 @@
 - Handle case where `.devops-ai/project.md` exists but has missing/empty sections
 - Essential vs optional values differ per skill (see SCENARIOS.md mapping)
 - "Not configured" markers in template should be treated same as missing
+
+## Task 3.3 Complete: Handle Partial Config
+
+**Added partial-config handling** to the "file exists" path in all 5 skills:
+- kdesign, kdesign-validate: all values essential — ask if missing/Not configured
+- kdesign-impl-plan, ktask, kmilestone: essential values asked for, optional values (Infrastructure, E2E) skipped silently with brief note
+- All 3 skills with optional values include "Do NOT offer to update the config file unless the user asks"
+
+**Next Task Notes (3.4 — verify degradation paths):**
+- Trace all 6 scenarios from the task description through all 5 skills
+- Fix any dead ends or inconsistencies found

--- a/skills/kdesign-impl-plan/SKILL.md
+++ b/skills/kdesign-impl-plan/SKILL.md
@@ -36,8 +36,8 @@ Generate a vertical implementation plan from validated design and architecture d
    - Ask: "What command runs your unit tests?"
    - Ask: "What command runs quality/lint checks?"
    - Ask: "Where do you store design documents?" (default: `docs/designs/`)
-   - Note: Infrastructure and E2E features require config. These sections will be skipped.
-   - Suggest creating config for future sessions.
+   - Note: Infrastructure and E2E sections will be skipped (these require config to be useful).
+   - Suggest: "Would you like me to create a `.devops-ai/project.md` so future sessions pick up these values automatically?"
 4. Use the configured values throughout this workflow
 
 ---

--- a/skills/kdesign-impl-plan/SKILL.md
+++ b/skills/kdesign-impl-plan/SKILL.md
@@ -40,6 +40,20 @@ Generate a vertical implementation plan from validated design and architecture d
    - Suggest: "Would you like me to create a `.devops-ai/project.md` so future sessions pick up these values automatically?"
 4. Use the configured values throughout this workflow
 
+### Generating Config (if user accepts)
+
+If the user wants to create a config file:
+
+1. **Inspect the project root** for project type indicators:
+   - `pyproject.toml` → Python (extract project name, look for test commands in `[tool.pytest]`, `[tool.ruff]`)
+   - `package.json` → Node/TypeScript (extract `name`, `scripts.test`, `scripts.lint`)
+   - `Makefile` → Look for `test`, `quality`, `lint`, `check` targets
+   - `go.mod` → Go (extract module name)
+   - `Cargo.toml` → Rust (extract `[package].name`)
+2. **Pre-fill values** from what you found (project name, test commands, quality commands)
+3. **Show the draft config** to the user and ask them to confirm or adjust
+4. **Write** `.devops-ai/project.md` using the template structure from `templates/project-config.md`
+
 ---
 
 ## This is a Conversation, Not a Generator

--- a/skills/kdesign-impl-plan/SKILL.md
+++ b/skills/kdesign-impl-plan/SKILL.md
@@ -35,6 +35,7 @@ Generate a vertical implementation plan from validated design and architecture d
    - If essential values (Testing.*, Paths.*) are missing or say "Not configured": ask for them
    - If optional values (Infrastructure, E2E) are missing or say "Not configured": skip those sections silently — note briefly what was skipped
    - Do NOT offer to update the config file unless the user asks
+   - If the file exists but is malformed (no recognizable sections, garbled content): suggest starting from the template at `templates/project-config.md` and fall back to the no-config path
 3. If the file does NOT exist:
    - Ask: "What command runs your unit tests?"
    - Ask: "What command runs quality/lint checks?"

--- a/skills/kdesign-impl-plan/SKILL.md
+++ b/skills/kdesign-impl-plan/SKILL.md
@@ -32,6 +32,9 @@ Generate a vertical implementation plan from validated design and architecture d
    - **Infrastructure** — whether infrastructure exists and commands
    - **E2E** — whether E2E testing is configured
    - **Paths.design_documents** — where design docs are stored
+   - If essential values (Testing.*, Paths.*) are missing or say "Not configured": ask for them
+   - If optional values (Infrastructure, E2E) are missing or say "Not configured": skip those sections silently — note briefly what was skipped
+   - Do NOT offer to update the config file unless the user asks
 3. If the file does NOT exist:
    - Ask: "What command runs your unit tests?"
    - Ask: "What command runs quality/lint checks?"

--- a/skills/kdesign-validate/SKILL.md
+++ b/skills/kdesign-validate/SKILL.md
@@ -30,6 +30,7 @@ Validate a design by walking through concrete scenarios before implementation be
    - **Project.name** — used in document headers and context
    - **Paths.design_documents** — where design docs are stored
    - If a value is missing or says "Not configured": ask for it, just like the no-config path
+   - If the file exists but is malformed (no recognizable sections, garbled content): suggest starting from the template at `templates/project-config.md` and fall back to the no-config path
 3. If the file does NOT exist:
    - Ask: "Where do you store design documents?" (default: `docs/designs/`)
    - Ask: "What's the project name?"

--- a/skills/kdesign-validate/SKILL.md
+++ b/skills/kdesign-validate/SKILL.md
@@ -36,6 +36,20 @@ Validate a design by walking through concrete scenarios before implementation be
    - Suggest: "Would you like me to create a `.devops-ai/project.md` so future sessions pick up these values automatically?"
 4. Use the configured values throughout this workflow
 
+### Generating Config (if user accepts)
+
+If the user wants to create a config file:
+
+1. **Inspect the project root** for project type indicators:
+   - `pyproject.toml` → Python (extract project name, look for test commands in `[tool.pytest]`, `[tool.ruff]`)
+   - `package.json` → Node/TypeScript (extract `name`, `scripts.test`, `scripts.lint`)
+   - `Makefile` → Look for `test`, `quality`, `lint`, `check` targets
+   - `go.mod` → Go (extract module name)
+   - `Cargo.toml` → Rust (extract `[package].name`)
+2. **Pre-fill values** from what you found (project name, test commands, quality commands)
+3. **Show the draft config** to the user and ask them to confirm or adjust
+4. **Write** `.devops-ai/project.md` using the template structure from `templates/project-config.md`
+
 ---
 
 ## This is a Conversation, Not a Report

--- a/skills/kdesign-validate/SKILL.md
+++ b/skills/kdesign-validate/SKILL.md
@@ -29,6 +29,7 @@ Validate a design by walking through concrete scenarios before implementation be
 2. If the file exists, extract:
    - **Project.name** — used in document headers and context
    - **Paths.design_documents** — where design docs are stored
+   - If a value is missing or says "Not configured": ask for it, just like the no-config path
 3. If the file does NOT exist:
    - Ask: "Where do you store design documents?" (default: `docs/designs/`)
    - Ask: "What's the project name?"

--- a/skills/kdesign-validate/SKILL.md
+++ b/skills/kdesign-validate/SKILL.md
@@ -32,7 +32,8 @@ Validate a design by walking through concrete scenarios before implementation be
 3. If the file does NOT exist:
    - Ask: "Where do you store design documents?" (default: `docs/designs/`)
    - Ask: "What's the project name?"
-   - Proceed with answers. Suggest creating config for future sessions.
+   - Proceed with answers
+   - Suggest: "Would you like me to create a `.devops-ai/project.md` so future sessions pick up these values automatically?"
 4. Use the configured values throughout this workflow
 
 ---

--- a/skills/kdesign/SKILL.md
+++ b/skills/kdesign/SKILL.md
@@ -22,6 +22,7 @@ This command embodies partnership values — craftsmanship over completion, hone
    - **Project.name** — used in document headers and context
    - **Paths.design_documents** — where to save design docs (e.g., `docs/designs/`)
    - If a value is missing or says "Not configured": ask for it, just like the no-config path
+   - If the file exists but is malformed (no recognizable sections, garbled content): suggest starting from the template at `templates/project-config.md` and fall back to the no-config path
 3. If the file does NOT exist:
    - Ask: "Where do you store design documents?" (default: `docs/designs/`)
    - Ask: "What's the project name?"

--- a/skills/kdesign/SKILL.md
+++ b/skills/kdesign/SKILL.md
@@ -28,6 +28,20 @@ This command embodies partnership values — craftsmanship over completion, hone
    - Suggest: "Would you like me to create a `.devops-ai/project.md` so future sessions pick up these values automatically?"
 4. Use the configured values throughout this workflow
 
+### Generating Config (if user accepts)
+
+If the user wants to create a config file:
+
+1. **Inspect the project root** for project type indicators:
+   - `pyproject.toml` → Python (extract project name, look for test commands in `[tool.pytest]`, `[tool.ruff]`)
+   - `package.json` → Node/TypeScript (extract `name`, `scripts.test`, `scripts.lint`)
+   - `Makefile` → Look for `test`, `quality`, `lint`, `check` targets
+   - `go.mod` → Go (extract module name)
+   - `Cargo.toml` → Rust (extract `[package].name`)
+2. **Pre-fill values** from what you found (project name, test commands, quality commands)
+3. **Show the draft config** to the user and ask them to confirm or adjust
+4. **Write** `.devops-ai/project.md` using the template structure from `templates/project-config.md`
+
 ---
 
 ## Command Usage

--- a/skills/kdesign/SKILL.md
+++ b/skills/kdesign/SKILL.md
@@ -21,6 +21,7 @@ This command embodies partnership values — craftsmanship over completion, hone
 2. If the file exists, extract:
    - **Project.name** — used in document headers and context
    - **Paths.design_documents** — where to save design docs (e.g., `docs/designs/`)
+   - If a value is missing or says "Not configured": ask for it, just like the no-config path
 3. If the file does NOT exist:
    - Ask: "Where do you store design documents?" (default: `docs/designs/`)
    - Ask: "What's the project name?"

--- a/skills/kdesign/SKILL.md
+++ b/skills/kdesign/SKILL.md
@@ -24,7 +24,8 @@ This command embodies partnership values — craftsmanship over completion, hone
 3. If the file does NOT exist:
    - Ask: "Where do you store design documents?" (default: `docs/designs/`)
    - Ask: "What's the project name?"
-   - Proceed with answers. Suggest creating config for future sessions.
+   - Proceed with answers
+   - Suggest: "Would you like me to create a `.devops-ai/project.md` so future sessions pick up these values automatically?"
 4. Use the configured values throughout this workflow
 
 ---

--- a/skills/kmilestone/SKILL.md
+++ b/skills/kmilestone/SKILL.md
@@ -21,6 +21,9 @@ Executes an entire milestone by invoking `/ktask` for each task, with context co
    - **Testing.unit_tests** — command to run unit tests (used in verification)
    - **Testing.quality_checks** — command to run quality checks (used in verification)
    - **E2E.enabled** — whether E2E testing is configured
+   - If essential values (Testing.*) are missing or say "Not configured": ask for them
+   - If optional values (E2E) are missing or say "Not configured": skip those sections silently — note briefly what was skipped
+   - Do NOT offer to update the config file unless the user asks
 3. If the file does NOT exist:
    - Ask: "What command runs your unit tests?" (default: `pytest tests/`)
    - Ask: "What command runs quality checks?" (default: none)

--- a/skills/kmilestone/SKILL.md
+++ b/skills/kmilestone/SKILL.md
@@ -29,6 +29,20 @@ Executes an entire milestone by invoking `/ktask` for each task, with context co
    - Suggest: "Would you like me to create a `.devops-ai/project.md` so future sessions pick up these values automatically?"
 4. Use the configured values throughout this workflow
 
+### Generating Config (if user accepts)
+
+If the user wants to create a config file:
+
+1. **Inspect the project root** for project type indicators:
+   - `pyproject.toml` → Python (extract project name, look for test commands in `[tool.pytest]`, `[tool.ruff]`)
+   - `package.json` → Node/TypeScript (extract `name`, `scripts.test`, `scripts.lint`)
+   - `Makefile` → Look for `test`, `quality`, `lint`, `check` targets
+   - `go.mod` → Go (extract module name)
+   - `Cargo.toml` → Rust (extract `[package].name`)
+2. **Pre-fill values** from what you found (project name, test commands, quality commands)
+3. **Show the draft config** to the user and ask them to confirm or adjust
+4. **Write** `.devops-ai/project.md` using the template structure from `templates/project-config.md`
+
 ---
 
 ## Command Usage

--- a/skills/kmilestone/SKILL.md
+++ b/skills/kmilestone/SKILL.md
@@ -24,6 +24,7 @@ Executes an entire milestone by invoking `/ktask` for each task, with context co
    - If essential values (Testing.*) are missing or say "Not configured": ask for them
    - If optional values (E2E) are missing or say "Not configured": skip those sections silently — note briefly what was skipped
    - Do NOT offer to update the config file unless the user asks
+   - If the file exists but is malformed (no recognizable sections, garbled content): suggest starting from the template at `templates/project-config.md` and fall back to the no-config path
 3. If the file does NOT exist:
    - Ask: "What command runs your unit tests?" (default: `pytest tests/`)
    - Ask: "What command runs quality checks?" (default: none)

--- a/skills/kmilestone/SKILL.md
+++ b/skills/kmilestone/SKILL.md
@@ -24,7 +24,9 @@ Executes an entire milestone by invoking `/ktask` for each task, with context co
 3. If the file does NOT exist:
    - Ask: "What command runs your unit tests?" (default: `pytest tests/`)
    - Ask: "What command runs quality checks?" (default: none)
-   - Proceed with answers. Suggest creating config for future sessions.
+   - Note: E2E agent workflow sections will be skipped (these require config).
+   - Proceed with answers
+   - Suggest: "Would you like me to create a `.devops-ai/project.md` so future sessions pick up these values automatically?"
 4. Use the configured values throughout this workflow
 
 ---

--- a/skills/ktask/SKILL.md
+++ b/skills/ktask/SKILL.md
@@ -28,6 +28,7 @@ This command embodies partnership values — craftsmanship over completion, hone
    - If essential values (Testing.*) are missing or say "Not configured": ask for them
    - If optional values (Infrastructure, E2E) are missing or say "Not configured": skip those sections silently — note briefly what was skipped
    - Do NOT offer to update the config file unless the user asks
+   - If the file exists but is malformed (no recognizable sections, garbled content): suggest starting from the template at `templates/project-config.md` and fall back to the no-config path
 3. If the file does NOT exist:
    - Ask: "What command runs your unit tests?" (default: `pytest tests/`)
    - Ask: "What command runs quality checks?" (default: none)

--- a/skills/ktask/SKILL.md
+++ b/skills/ktask/SKILL.md
@@ -25,6 +25,9 @@ This command embodies partnership values — craftsmanship over completion, hone
    - **Infrastructure.start** — command to start infrastructure (e.g., `docker compose up -d`)
    - **Infrastructure.logs** — command to check logs (e.g., `docker compose logs backend --since 5m`)
    - **E2E.enabled** — whether E2E testing is configured
+   - If essential values (Testing.*) are missing or say "Not configured": ask for them
+   - If optional values (Infrastructure, E2E) are missing or say "Not configured": skip those sections silently — note briefly what was skipped
+   - Do NOT offer to update the config file unless the user asks
 3. If the file does NOT exist:
    - Ask: "What command runs your unit tests?" (default: `pytest tests/`)
    - Ask: "What command runs quality checks?" (default: none)

--- a/skills/ktask/SKILL.md
+++ b/skills/ktask/SKILL.md
@@ -32,8 +32,7 @@ This command embodies partnership values — craftsmanship over completion, hone
 3. If the file does NOT exist:
    - Ask: "What command runs your unit tests?" (default: `pytest tests/`)
    - Ask: "What command runs quality checks?" (default: none)
-   - Ask: "Does this project use infrastructure (Docker, databases, etc.)?" (default: no)
-   - Note: If no infrastructure, integration smoke test and E2E sections will be skipped.
+   - Note: Infrastructure, integration smoke test, and E2E sections will be skipped (these require config).
    - Proceed with answers
    - Suggest: "Would you like me to create a `.devops-ai/project.md` so future sessions pick up these values automatically?"
 4. Use the configured values throughout this workflow

--- a/skills/ktask/SKILL.md
+++ b/skills/ktask/SKILL.md
@@ -29,7 +29,9 @@ This command embodies partnership values — craftsmanship over completion, hone
    - Ask: "What command runs your unit tests?" (default: `pytest tests/`)
    - Ask: "What command runs quality checks?" (default: none)
    - Ask: "Does this project use infrastructure (Docker, databases, etc.)?" (default: no)
-   - Proceed with answers. Suggest creating config for future sessions.
+   - Note: If no infrastructure, integration smoke test and E2E sections will be skipped.
+   - Proceed with answers
+   - Suggest: "Would you like me to create a `.devops-ai/project.md` so future sessions pick up these values automatically?"
 4. Use the configured values throughout this workflow
 
 ---

--- a/skills/ktask/SKILL.md
+++ b/skills/ktask/SKILL.md
@@ -34,6 +34,20 @@ This command embodies partnership values — craftsmanship over completion, hone
    - Suggest: "Would you like me to create a `.devops-ai/project.md` so future sessions pick up these values automatically?"
 4. Use the configured values throughout this workflow
 
+### Generating Config (if user accepts)
+
+If the user wants to create a config file:
+
+1. **Inspect the project root** for project type indicators:
+   - `pyproject.toml` → Python (extract project name, look for test commands in `[tool.pytest]`, `[tool.ruff]`)
+   - `package.json` → Node/TypeScript (extract `name`, `scripts.test`, `scripts.lint`)
+   - `Makefile` → Look for `test`, `quality`, `lint`, `check` targets
+   - `go.mod` → Go (extract module name)
+   - `Cargo.toml` → Rust (extract `[package].name`)
+2. **Pre-fill values** from what you found (project name, test commands, quality commands)
+3. **Show the draft config** to the user and ask them to confirm or adjust
+4. **Write** `.devops-ai/project.md` using the template structure from `templates/project-config.md`
+
 ---
 
 ## Command Usage


### PR DESCRIPTION
## Summary

- All 5 skills now gracefully degrade across 6 configuration scenarios: full config, no config, partial essential, partial optional, declined config creation, and malformed config
- Added config generation capability — skills can inspect project root (pyproject.toml, package.json, Makefile, go.mod, Cargo.toml) and pre-fill `.devops-ai/project.md`
- Essential vs optional config values handled per-skill: essential values prompt the user, optional values skip silently with a brief note

## Changes

- **Task 3.1**: Explicit no-config behavior — all skills suggest creating config, note which sections get skipped
- **Task 3.2**: Config generation — 4-step inspection/pre-fill/confirm/write block in all 5 skills
- **Task 3.3**: Partial config handling — essential values asked for, optional values skipped silently
- **Task 3.4**: Verification — traced 6 scenarios × 5 skills, found and fixed malformed config gap

## Test plan

- [ ] Verify each skill's Configuration Loading section has all 3 paths (full config, partial config, no config)
- [ ] Verify malformed config handling present in all 5 skills
- [ ] Verify config generation subsection present in all 5 skills
- [ ] Verify essential vs optional value distinction is correct per skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)