### PR TITLE
docs(M4): documentation + polish + E2E validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,38 +35,71 @@ We are partners building devops-ai together. This section defines our collaborat
 devops-ai provides versioned, configuration-driven development workflow skills for AI-assisted software engineering.
 
 Key components:
-- **Skills** (`skills/`): Markdown command files that encode workflow patterns
+- **Skills** (`skills/`): Markdown command files that encode workflow patterns (Agent Skills standard)
+- **Shared resources** (`skills/shared/`): Cross-skill reference docs (e.g., E2E testing workflow)
 - **Templates** (`templates/`): Bootstrap files for new projects
-- **Docs** (`docs/`): Design documents and patterns
+- **Docs** (`docs/`): Design documents, architecture, and implementation plans
 
 ## Project Structure
 
 ```
 devops-ai/
-├── AGENTS.md              # This file
-├── README.md              # Overview and quick start
+├── AGENTS.md              # This file — guidance for AI assistants
+├── README.md              # User-facing overview and quick start
 ├── install.sh             # Multi-tool symlink installer
-├── skills/                # The actual skill files (Agent Skills standard)
+├── skills/                # Skill files (Agent Skills standard)
 │   ├── kdesign/
-│   │   └── SKILL.md
+│   │   └── SKILL.md       # Design document generation
 │   ├── kdesign-validate/
-│   │   └── SKILL.md
+│   │   └── SKILL.md       # Scenario-based design validation
 │   ├── kdesign-impl-plan/
-│   │   └── SKILL.md
+│   │   └── SKILL.md       # Vertical implementation planning
 │   ├── kmilestone/
-│   │   └── SKILL.md
-│   └── ktask/
-│       └── SKILL.md
+│   │   └── SKILL.md       # Milestone orchestration
+│   ├── ktask/
+│   │   └── SKILL.md       # TDD task execution
+│   └── shared/
+│       └── e2e-prompt.md   # E2E testing workflow (referenced by ktask, kmilestone)
 ├── templates/             # Bootstrap templates
-│   ├── project-config.md
-│   └── AGENTS.md.template
+│   ├── project-config.md  # Config template for .devops-ai/project.md
+│   └── AGENTS.md.template # AGENTS.md template for new projects
 └── docs/
     └── designs/
         └── skill-generalization/
             ├── DESIGN.md
             ├── ARCHITECTURE.md
-            └── SCENARIOS.md
+            ├── SCENARIOS.md
+            ├── research/              # Agent Skills standard research
+            └── implementation/        # Milestone plans and handoffs
+                ├── OVERVIEW.md
+                ├── M1_foundation.md
+                ├── M2_skills.md
+                ├── M3_degradation.md
+                ├── M4_documentation.md
+                └── HANDOFF_M*.md
 ```
+
+## Development Workflow
+
+### Modifying skills
+
+1. Edit `skills/<name>/SKILL.md` directly
+2. Changes take effect immediately — symlinks point to this repo
+3. Test by invoking the skill in Claude Code (or Codex/Copilot)
+
+### Adding a new skill
+
+1. Create `skills/<name>/SKILL.md` with YAML frontmatter (`name`, `description`, `metadata.version`)
+2. Run `./install.sh` to create symlinks for the new skill
+3. Follow the Agent Skills standard: directory-based, `SKILL.md` entry point
+
+### Updating install targets
+
+`install.sh` auto-discovers all directories under `skills/`. No changes needed when adding skills — just create the directory and re-run.
+
+### Testing changes
+
+Skills are markdown prompts, not executable code. Testing means invoking them in an AI tool and verifying behavior. The design docs in `docs/designs/skill-generalization/` describe expected behavior for each skill.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd ~/Documents/dev/devops-ai
 ./install.sh
 ```
 
-This symlinks all skills to each tool's `skills/` directory (`~/.claude/skills/`, `~/.codex/skills/`, `~/.copilot/skills/`). Skills follow the [Agent Skills standard](https://agentskills.io) for cross-tool portability.
+This symlinks all skills to each tool's `skills/` directory (`~/.claude/skills/`, `~/.codex/skills/`, `~/.copilot/skills/`). Use `--target claude` to install for a single tool only.
 
 ### 2. Configure a project
 
@@ -37,28 +37,95 @@ cp ~/Documents/dev/devops-ai/templates/project-config.md .devops-ai/project.md
 # Edit .devops-ai/project.md with your project's commands and paths
 ```
 
+Or skip this step — skills will ask for needed values and offer to create the config.
+
 ### 3. Use the commands
 
 ```bash
-# In Claude Code:
+# In Claude Code (or Codex, Copilot):
 /kdesign feature: Add user authentication
-/ktask M1_auth.md 1.2
+/kdesign-validate design: DESIGN.md arch: ARCHITECTURE.md
+/kdesign-impl-plan design: DESIGN.md arch: ARCHITECTURE.md
 /kmilestone @M1_auth.md
+/ktask M1_auth.md 1.2
 ```
+
+## Workflow
+
+The commands chain together in a design-to-implementation pipeline:
+
+```
+/kdesign          → DESIGN.md + ARCHITECTURE.md    (what + how)
+/kdesign-validate → SCENARIOS.md                    (does it hold up?)
+/kdesign-impl-plan → M1_*.md, M2_*.md, ...         (vertical milestones)
+/kmilestone        → orchestrates /ktask per task    (execute milestone)
+/ktask             → TDD implementation + handoffs   (execute task)
+```
+
+Each stage produces artifacts consumed by the next. You can enter at any point — `/ktask` works fine standalone with a hand-written task list.
+
+## Commands
+
+### `/kdesign`
+
+Generates DESIGN.md and ARCHITECTURE.md through collaborative exploration. Asks clarifying questions, proposes options with trade-offs, pauses for alignment at each stage.
+
+**Produces:** `DESIGN.md`, `ARCHITECTURE.md` in configured design path.
+
+### `/kdesign-validate`
+
+Walks through concrete scenarios against the design, catching gaps before implementation. Traces execution paths, identifies missing state transitions, and produces interface contracts.
+
+**Produces:** `SCENARIOS.md` with validated scenarios and milestone structure.
+
+### `/kdesign-impl-plan`
+
+Generates vertical implementation plans where each milestone delivers an E2E-testable capability. Includes detailed tasks with files, acceptance criteria, and test requirements.
+
+**Produces:** One file per milestone (`M1_*.md`, `M2_*.md`, ...) plus `OVERVIEW.md`.
+
+### `/kmilestone`
+
+Orchestrates execution of an entire milestone by invoking `/ktask` for each task. Tracks progress via handoff files, verifies quality gates between tasks, and produces a completion summary.
+
+**Usage:** `/kmilestone @M1_foundation.md`
+
+### `/ktask`
+
+Implements individual tasks using TDD methodology: RED (write failing tests) → GREEN (minimal implementation) → REFACTOR (clean up). Updates handoff documents for context continuity.
+
+**Usage:** `/ktask M1_foundation.md 1.2`
+
+## Configuration
+
+Skills read `.devops-ai/project.md` from your project root. Copy the template from `templates/project-config.md` and fill in your values.
+
+**Sections:**
+
+| Section | Used By | Required |
+|---------|---------|----------|
+| **Project** (name, language) | All skills | For context |
+| **Testing** (unit tests, quality checks) | ktask, kmilestone, kdesign-impl-plan | Essential |
+| **Infrastructure** (start, logs) | ktask | Optional |
+| **E2E Testing** (system, catalog) | ktask, kmilestone, kdesign-impl-plan | Optional |
+| **Paths** (design docs) | kdesign, kdesign-validate, kdesign-impl-plan | Essential |
+| **Project-Specific Patterns** | ktask | Optional |
+
+Without a config file, skills ask for essential values and skip optional sections.
 
 ## How It Works
 
-Skills are markdown prompts that instruct AI coding tools (Claude Code, Codex, Copilot). Each skill starts by reading your project's `.devops-ai/project.md` to learn project-specific values (test commands, paths, infrastructure). The core workflow patterns are universal; the tooling adapts.
+Skills are markdown prompts that instruct AI coding tools. Each skill starts by reading your project's `.devops-ai/project.md` to learn project-specific values. The core workflow patterns are universal; the tooling adapts.
 
 ```
 devops-ai (versioned)        ~/.claude/skills/ (symlinks)         your-project/
 ├── skills/                  ├── kdesign/ →                       ├── .devops-ai/
 │   ├── kdesign/SKILL.md ───┤── ktask/ →                         │   └── project.md  ← config
-│   ├── ktask/SKILL.md ─────┤── kmilestone/ →                    └── AGENTS.md
+│   ├── ktask/SKILL.md ─────┤── kmilestone/ →                    └── ...
 │   └── ...                  └── ...
 ```
 
-Same symlinks are created for `~/.codex/skills/` and `~/.copilot/skills/` when those tools are detected.
+Same symlinks are created for `~/.codex/skills/` and `~/.copilot/skills/`.
 
 ## Design Principles
 
@@ -69,24 +136,29 @@ Same symlinks are created for `~/.codex/skills/` and `~/.copilot/skills/` when t
 5. **Conditional capabilities** — E2E testing, Docker infrastructure are optional
 6. **Agent Skills standard** — Cross-tool portable via [agentskills.io](https://agentskills.io) spec
 
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "Command not found" when using `/kdesign` etc. | Run `./install.sh` from the devops-ai directory |
+| Skills not picking up config | Verify `.devops-ai/project.md` exists in your project root |
+| Skills not updating after `git pull` | Check symlinks: `ls -la ~/.claude/skills/kdesign` should point to devops-ai |
+| Broken symlinks after moving devops-ai | Re-run `./install.sh` |
+| Skills ask for values that are in config | Check for "Not configured" placeholders — replace them with actual values |
+
 ## Relationship to Other Projects
 
 | Project | Purpose | Visibility |
 |---------|---------|------------|
 | **devops-ai** (this) | Development workflow skills | Public (eventually) |
 | **agent-memory** | Memory infrastructure (store, retrieve, consolidate) | Public (eventually) |
-| **Lux** | Private memory content | Private |
 
 ## Status
 
-Early development. Current focus: generalizing skills from ktrdr-specific to portable.
+Early development. Current focus: generalizing skills from project-specific to portable.
 
-See: `docs/designs/skill-generalization/` for design and architecture documents.
+See `docs/designs/skill-generalization/` for design and architecture documents.
 
 ## License
 
 TBD — considering open source once stable.
-
----
-
-*Created: 2026-02-04*

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M4.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M4.md
@@ -1,0 +1,15 @@
+# M4 Handoff
+
+## Task 4.1 Complete: Update README with Complete Documentation
+
+**Expanded README from 93 to 165 lines** (under 200-line target). Added:
+- Workflow pipeline diagram showing command chaining
+- Per-command documentation (what it does, what it produces, usage)
+- Configuration guide with per-section table (which skills use what, required vs optional)
+- Troubleshooting table (5 common issues)
+- Removed Lux from "Relationship" table (private, shouldn't be in public README)
+
+**Next Task Notes (4.2 — AGENTS.md):**
+- Check actual file tree against what AGENTS.md describes
+- Add `skills/shared/` and `implementation/` docs to structure
+- Add development workflow section

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M4.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M4.md
@@ -21,3 +21,14 @@
 **Next Task Notes (4.3 — E2E Validation):**
 - VALIDATION task — verify install, config, skill invocation, no-config, cross-skill references
 - This is documentation-only milestone so "E2E" means manual verification, not agent-based
+
+## Task 4.3 Complete: End-to-End Validation
+
+All 5 validation steps passed:
+1. Fresh install: 6 skills symlinked to `~/.claude/skills/`
+2. New project setup: config template has all 6 sections
+3. README completeness: all 5 commands, workflow, config guide, troubleshooting (164 lines)
+4. Cross-skill references: all chains verified (kdesign→validate→impl-plan→ktask, kmilestone→ktask)
+5. No-config degradation: all 5 skills have config suggestion + malformed handling
+
+**Fix applied during validation:** Added "Next Steps" section to kdesign-validate pointing to `/kdesign-impl-plan` (was the only missing cross-skill reference).

--- a/docs/designs/skill-generalization/implementation/HANDOFF_M4.md
+++ b/docs/designs/skill-generalization/implementation/HANDOFF_M4.md
@@ -13,3 +13,11 @@
 - Check actual file tree against what AGENTS.md describes
 - Add `skills/shared/` and `implementation/` docs to structure
 - Add development workflow section
+
+## Task 4.2 Complete: Update AGENTS.md
+
+**Updated project structure** to match actual repo — added `skills/shared/`, `implementation/`, `research/` directories. Added descriptions to each file in the tree. Added **Development Workflow** section covering: modifying skills, adding new skills, updating install, testing changes.
+
+**Next Task Notes (4.3 — E2E Validation):**
+- VALIDATION task — verify install, config, skill invocation, no-config, cross-skill references
+- This is documentation-only milestone so "E2E" means manual verification, not agent-based

--- a/skills/kdesign-validate/SKILL.md
+++ b/skills/kdesign-validate/SKILL.md
@@ -593,3 +593,15 @@ The key difference: tasks within a milestone are all working toward one E2E-test
 3. **Treating gaps as failures** — Finding gaps is the point. A validation that finds nothing is suspicious.
 
 4. **Over-documenting** — The conversation matters more than the artifact. Save decisions and scenarios, not every trace.
+
+---
+
+## Next Steps
+
+After validation is complete:
+
+```
+/kdesign-impl-plan design: DESIGN.md arch: ARCHITECTURE.md validation: SCENARIOS.md
+```
+
+This expands the validated milestone structure into detailed, implementable tasks.


### PR DESCRIPTION
## Summary

- README expanded with complete user documentation: workflow pipeline, per-command docs, configuration guide, troubleshooting (164 lines, under 200 target)
- AGENTS.md updated to match actual repo structure (added shared/, implementation/, research/) with development workflow section
- End-to-end validation passed all 5 checks: fresh install, project setup, README completeness, cross-skill references, no-config degradation
- Fixed missing cross-skill reference: kdesign-validate now points to kdesign-impl-plan in "Next Steps"

## Test plan

- [ ] Verify README has all 5 commands documented with workflow chain
- [ ] Verify AGENTS.md project structure matches actual file tree
- [ ] Run `./install.sh --target claude` and verify symlinks
- [ ] Verify cross-skill references: kdesign → validate → impl-plan → ktask

🤖 Generated with [Claude Code](https://claude.com/claude-code)