### PR TITLE
feat(M4): agent-deck integration, --session flag, kworktree skill

### DIFF
--- a/docs/designs/kinfra-kworktree/implementation/HANDOFF_M4.md
+++ b/docs/designs/kinfra-kworktree/implementation/HANDOFF_M4.md
@@ -1,0 +1,15 @@
+# Handoff — Milestone 4: Agent-Deck Integration + kworktree Skill
+
+## Task 4.1 Complete: Agent-Deck Module
+
+**Approach:** Standalone module using `functools.lru_cache` for `is_available()` caching and a private `_run_command()` helper for all subprocess calls. All public functions check availability first and return early if not available.
+
+**Key patterns:**
+- `is_available()` uses `lru_cache(maxsize=1)` — tests must call `is_available.cache_clear()` in `setup_method`
+- `_run_command()` handles all subprocess calls: `capture_output=True, text=True`, logs warning on failure stderr, never raises
+- `AgentDeckError` exists but not used yet — available for CLI layer to catch if needed
+
+**Next Task Notes (4.2):**
+- Import from `devops_ai.agent_deck`: `is_available`, `add_session`, `remove_session`, `start_session`, `send_to_session`
+- `impl_command()` currently returns `(exit_code, msg)` — add `session` parameter, call agent-deck after sandbox setup
+- `done_command()` — call `remove_session()` before sandbox stop (best-effort)

--- a/docs/designs/kinfra-kworktree/implementation/HANDOFF_M4.md
+++ b/docs/designs/kinfra-kworktree/implementation/HANDOFF_M4.md
@@ -9,7 +9,31 @@
 - `_run_command()` handles all subprocess calls: `capture_output=True, text=True`, logs warning on failure stderr, never raises
 - `AgentDeckError` exists but not used yet — available for CLI layer to catch if needed
 
-**Next Task Notes (4.2):**
-- Import from `devops_ai.agent_deck`: `is_available`, `add_session`, `remove_session`, `start_session`, `send_to_session`
-- `impl_command()` currently returns `(exit_code, msg)` — add `session` parameter, call agent-deck after sandbox setup
-- `done_command()` — call `remove_session()` before sandbox stop (best-effort)
+## Task 4.2 Complete: CLI --session Flag Integration
+
+**Approach:** Added `_setup_session()` helper in impl.py that encapsulates the add→start→send sequence. Both no-sandbox and sandbox paths call it when `session=True`. done.py calls `remove_session(wt.feature)` before sandbox stop.
+
+**Key patterns:**
+- `import devops_ai.agent_deck as agent_deck` (module-level import) — tests mock it as `devops_ai.cli.impl.agent_deck`
+- `_setup_session()` returns a status message string, appended to the main output
+- `main.py` passes `session=` kwarg — `typer.Option(False, "--session", help="...")`
+- done.py uses `wt.feature` as the session title for removal
+
+## Task 4.3 Complete: kworktree Skill
+
+**Approach:** Single markdown skill at `skills/kworktree/SKILL.md` (167 lines). Covers context detection, all commands, workflows, sandbox-aware coding, observability endpoints, error handling, and project config reference.
+
+**Key decisions:**
+- Compressed workflow section to single-line format to stay under 200 lines
+- Referenced `infra.toml` conceptually rather than including full example (saves ~12 lines)
+- Observability endpoints hardcoded (they're fixed at 4xxxx range)
+
+## Task 4.4 Complete: M4 E2E Verification
+
+**Validation results:**
+- Unit tests: 166/166 PASSED
+- Ruff: All checks passed
+- Mypy: No issues (18 source files)
+- Skill structural checks: All 7 command references present, 167 lines
+- Regression: 143 pre-existing tests (M1-M3) all pass
+- agent-deck: Available on system at /opt/homebrew/bin/agent-deck

--- a/docs/designs/kinfra-kworktree/implementation/HANDOFF_M4.md
+++ b/docs/designs/kinfra-kworktree/implementation/HANDOFF_M4.md
@@ -11,13 +11,13 @@
 
 ## Task 4.2 Complete: CLI --session Flag Integration
 
-**Approach:** Added `_setup_session()` helper in impl.py that encapsulates the add→start→send sequence. Both no-sandbox and sandbox paths call it when `session=True`. done.py calls `remove_session(wt.feature)` before sandbox stop.
+**Approach:** Added `_setup_session()` helper in impl.py that encapsulates the add→start→send sequence. Both no-sandbox and sandbox paths call it when `session=True`. done.py uses `_session_title_from_worktree()` to derive the session title from the branch name.
 
 **Key patterns:**
 - `import devops_ai.agent_deck as agent_deck` (module-level import) — tests mock it as `devops_ai.cli.impl.agent_deck`
 - `_setup_session()` returns a status message string, appended to the main output
 - `main.py` passes `session=` kwarg — `typer.Option(False, "--session", help="...")`
-- done.py uses `wt.feature` as the session title for removal
+- done.py derives title from branch: `impl/feat-M1` → `feat/M1`, `spec/feat` → `spec/feat`
 
 ## Task 4.3 Complete: kworktree Skill
 
@@ -30,10 +30,14 @@
 
 ## Task 4.4 Complete: M4 E2E Verification
 
+**Bugs found and fixed during real E2E testing:**
+
+1. **add_session CLI syntax** — Code used `agent-deck add <title> --group <group> --path <path>` but real CLI expects `agent-deck add <path> -t <title> -g <group>`. Fixed in `agent_deck.py`.
+
+2. **done session title mismatch** — `done_command` passed `wt.feature` (hyphenated: `feat-M1`) but sessions are created with slash format (`feat/M1`). Fixed by adding `_session_title_from_worktree()` that derives title from branch name using regex.
+
 **Validation results:**
-- Unit tests: 166/166 PASSED
-- Ruff: All checks passed
-- Mypy: No issues (18 source files)
-- Skill structural checks: All 7 command references present, 167 lines
-- Regression: 143 pre-existing tests (M1-M3) all pass
-- agent-deck: Available on system at /opt/homebrew/bin/agent-deck
+- Unit tests: 172/172 PASSED (includes 6 new tests for bug fixes)
+- E2E tests: 7/7 PASSED (real agent-deck session lifecycle + skill structure)
+- Ruff + Mypy: All clean
+- Regression: All pre-existing tests (M1-M3) pass

--- a/skills/kworktree/SKILL.md
+++ b/skills/kworktree/SKILL.md
@@ -1,0 +1,167 @@
+# kworktree — Worktree & Sandbox Management
+
+Use this skill when the user asks to create, manage, or clean up development worktrees and sandboxes via `kinfra`.
+
+---
+
+## Context Detection
+
+Before running kinfra commands, determine where you are:
+
+```bash
+# Check if in a worktree
+git worktree list
+# Branch pattern: spec/<feature> or impl/<feature>-<milestone>
+
+# Check sandbox status
+kinfra status
+# Shows: slot ID, ports, project name (if in a sandbox worktree)
+```
+
+---
+
+## Commands Reference
+
+### `kinfra init`
+
+Initialize kinfra for the current project. Run once per project.
+
+```bash
+kinfra init
+# Interactive: detects compose file, services, ports
+# Generates: .devops-ai/infra.toml
+# Updates: docker-compose.yml (parameterizes host ports with env vars)
+```
+
+### `kinfra spec <feature>`
+
+Create a design worktree (no sandbox).
+
+```bash
+kinfra spec wellness-reminders
+# Creates: ../<prefix>-spec-wellness-reminders/
+# Branch: spec/wellness-reminders
+# Design dir: docs/designs/wellness-reminders/
+```
+
+### `kinfra impl <feature>/<milestone> [--session]`
+
+Create an implementation worktree with sandbox.
+
+```bash
+kinfra impl wellness-reminders/M1
+# Creates worktree + claims slot + starts Docker sandbox
+# Output includes: slot ID, port mappings
+
+kinfra impl wellness-reminders/M1 --session
+# Same as above + creates agent-deck session with Claude
+# Sends: /kmilestone wellness-reminders/M1
+```
+
+### `kinfra done <name> [--force]`
+
+Remove a worktree and clean up its sandbox.
+
+```bash
+kinfra done wellness-reminders-M1
+# Stops sandbox, releases slot, removes worktree
+# Fails if uncommitted changes (use --force to override)
+
+kinfra done wellness-reminders-M1 --force
+# Removes even with dirty state
+```
+
+### `kinfra worktrees`
+
+List all active worktrees across the project.
+
+```bash
+kinfra worktrees
+# Shows: worktree name, type (spec/impl), slot, ports, status
+```
+
+### `kinfra status`
+
+Show sandbox details for the current directory.
+
+```bash
+kinfra status
+# Shows: project, slot ID, status, ports
+```
+
+### `kinfra observability up|down|status`
+
+Manage the shared observability stack.
+
+```bash
+kinfra observability up      # Start Jaeger + Grafana + Prometheus
+kinfra observability down    # Stop the stack
+kinfra observability status  # Show service health and endpoints
+```
+
+---
+
+## Workflows
+
+**Design (spec):** `kinfra spec <feature>` → work → `kinfra done <feature>`
+
+**Implementation (impl):** `kinfra impl <feature>/<milestone>` → work with sandbox → `kinfra done <feature>-<milestone>`
+
+**With agent-deck:** `kinfra impl <feature>/<milestone> --session` → Claude launches with `/kmilestone` → `kinfra done <feature>-<milestone>`
+
+---
+
+## Sandbox-Aware Coding
+
+When writing code that connects to services, use dynamic ports from `kinfra status` or environment variables from `.devops-ai/infra.toml`. Do NOT hardcode base ports.
+
+```python
+# WRONG — hardcoded port
+url = "http://localhost:8080/api/v1/health"
+
+# RIGHT — use the sandbox port from kinfra status
+# Check: kinfra status → API_PORT: 8081
+url = "http://localhost:8081/api/v1/health"
+```
+
+Port formula: `actual_port = base_port + slot_id`. The `.env.sandbox` file in the slot directory contains all port mappings as environment variables.
+
+For OTEL configuration in sandbox services:
+- Exporter endpoint: `http://devops-ai-jaeger:4317` (container network)
+- Resource attributes: `service.namespace=<project>-slot-<N>`
+
+---
+
+## Observability
+
+The shared observability stack serves all sandboxes:
+
+| Service    | URL                        | Purpose            |
+|------------|----------------------------|--------------------|
+| Jaeger UI  | http://localhost:46686     | Distributed traces |
+| Grafana    | http://localhost:43000     | Dashboards         |
+| Prometheus | http://localhost:49090     | Metrics            |
+| OTLP gRPC  | http://localhost:44317     | Trace ingestion    |
+
+Filter traces by namespace in Jaeger UI:
+- Service name format: `<project>-slot-<N>/<service>`
+- Example: `khealth-slot-1/wellness-agent`
+
+---
+
+## Error Handling
+
+| Situation | What to do |
+|-----------|------------|
+| `kinfra init` not run | Run `kinfra init` first — generates infra.toml |
+| Sandbox fails to start | Check `docker compose logs` in the slot directory |
+| Health check timeout | Services may still be starting — check logs |
+| Dirty worktree on done | Commit or stash changes, or use `--force` |
+| Port conflict | kinfra auto-selects next available slot |
+| agent-deck not installed | `--session` prints warning, impl still works |
+
+---
+
+## Project Configuration
+
+kinfra reads `.devops-ai/infra.toml` for project-specific settings (ports, compose file, health endpoint). All port values are base ports — kinfra offsets them by slot ID for isolation. Run `kinfra init` to generate this file.

--- a/skills/kworktree/SKILL.md
+++ b/skills/kworktree/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: kworktree
+description: Worktree and sandbox management via kinfra CLI commands.
+metadata:
+  version: "0.1.0"
+---
+
 # kworktree — Worktree & Sandbox Management
 
 Use this skill when the user asks to create, manage, or clean up development worktrees and sandboxes via `kinfra`.

--- a/src/devops_ai/agent_deck.py
+++ b/src/devops_ai/agent_deck.py
@@ -1,0 +1,71 @@
+"""Agent-deck integration — optional session management via agent-deck CLI."""
+
+from __future__ import annotations
+
+import functools
+import logging
+import shutil
+import subprocess
+import time
+
+logger = logging.getLogger(__name__)
+
+
+class AgentDeckError(Exception):
+    """Internal error for agent-deck operations.
+
+    Caught at CLI layer and turned into warnings.
+    """
+
+
+@functools.lru_cache(maxsize=1)
+def is_available() -> bool:
+    """Check if agent-deck is on PATH. Result is cached for process lifetime."""
+    return shutil.which("agent-deck") is not None
+
+
+def _run_command(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run an agent-deck command, logging warnings on failure.
+
+    Never raises — all failures are logged and returned.
+    """
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0 and result.stderr:
+        logger.warning(
+            "agent-deck command failed: %s — %s",
+            " ".join(cmd),
+            result.stderr.strip(),
+        )
+    return result
+
+
+def add_session(title: str, *, group: str, path: str) -> None:
+    """Add an agent-deck session."""
+    if not is_available():
+        return
+    _run_command(["agent-deck", "add", title, "--group", group, "--path", path])
+
+
+def remove_session(title: str) -> None:
+    """Remove an agent-deck session. Ignores errors (session may not exist)."""
+    if not is_available():
+        return
+    _run_command(["agent-deck", "remove", title])
+
+
+def start_session(title: str) -> None:
+    """Start an agent-deck session (launches Claude in a tmux pane)."""
+    if not is_available():
+        return
+    _run_command(["agent-deck", "session", "start", title])
+
+
+def send_to_session(title: str, message: str, delay: float = 3) -> None:
+    """Send a message to a running agent-deck session.
+
+    Waits ``delay`` seconds before sending to allow the agent to start.
+    """
+    if not is_available():
+        return
+    time.sleep(delay)
+    _run_command(["agent-deck", "session", "send", title, message])

--- a/src/devops_ai/agent_deck.py
+++ b/src/devops_ai/agent_deck.py
@@ -43,7 +43,11 @@ def add_session(title: str, *, group: str, path: str) -> None:
     """Add an agent-deck session."""
     if not is_available():
         return
-    _run_command(["agent-deck", "add", title, "--group", group, "--path", path])
+    _run_command([
+        "agent-deck", "add", path,
+        "-t", title,
+        "-g", group,
+    ])
 
 
 def remove_session(title: str) -> None:

--- a/src/devops_ai/cli/done.py
+++ b/src/devops_ai/cli/done.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from devops_ai import agent_deck
 from devops_ai.config import find_project_root, load_config
 from devops_ai.registry import (
     get_slot_for_worktree,
@@ -76,6 +77,10 @@ def done_command(
                 f"Worktree '{wt.feature}' has {detail}. "
                 "Use --force to remove anyway."
             )
+
+    # Agent-deck cleanup (best-effort, before sandbox stop)
+    if agent_deck.is_available():
+        agent_deck.remove_session(wt.feature)
 
     # Check registry for sandbox slot
     registry = load_registry()

--- a/src/devops_ai/cli/main.py
+++ b/src/devops_ai/cli/main.py
@@ -62,9 +62,14 @@ def impl_cmd(
     feature_milestone: str = typer.Argument(
         help="Feature/milestone (e.g., my-feature/M1)"
     ),
+    session: bool = typer.Option(
+        False,
+        "--session",
+        help="Create an agent-deck session with Claude",
+    ),
 ) -> None:
     """Create an implementation worktree with sandbox."""
-    code, msg = impl_command(feature_milestone)
+    code, msg = impl_command(feature_milestone, session=session)
     typer.echo(msg)
     raise typer.Exit(code)
 

--- a/tests/e2e/test_session_and_skill.py
+++ b/tests/e2e/test_session_and_skill.py
@@ -1,0 +1,177 @@
+"""E2E test: agent-deck session integration and kworktree skill verification."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from devops_ai.agent_deck import is_available
+from devops_ai.cli.done import done_command
+from devops_ai.cli.impl import impl_command
+
+
+def _agent_deck_sessions_json() -> list[dict]:
+    """Get current agent-deck sessions as parsed JSON."""
+    result = subprocess.run(
+        ["agent-deck", "list", "-json"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return []
+    return json.loads(result.stdout)
+
+
+def _agent_deck_remove(title: str) -> None:
+    """Best-effort remove an agent-deck session by title."""
+    subprocess.run(
+        ["agent-deck", "remove", title],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.e2e
+class TestSessionIntegration:
+    """Test --session flag against real agent-deck."""
+
+    @pytest.fixture(autouse=True)
+    def _check_agent_deck(self) -> None:
+        is_available.cache_clear()
+        if not is_available():
+            pytest.skip("agent-deck not installed")
+
+    def test_impl_session_creates_and_done_removes(
+        self, e2e_project: dict
+    ) -> None:
+        """impl --session creates agent-deck session, done removes it."""
+        repo_root: Path = e2e_project["repo_root"]
+        feature = e2e_project["feature"]
+        milestone = e2e_project["milestone"]
+        title = f"{feature}/{milestone}"
+
+        # Ensure no leftover session from previous run
+        _agent_deck_remove(title)
+
+        # ── Step 1: impl with --session ─────────────────────
+        code, msg = impl_command(
+            f"{feature}/{milestone}",
+            repo_root=repo_root,
+            session=True,
+        )
+        assert code == 0, f"impl_command failed: {msg}"
+        assert "agent-deck session started" in msg.lower()
+
+        # ── Step 2: Verify session exists in agent-deck ─────
+        sessions = _agent_deck_sessions_json()
+        titles = [s.get("title", "") for s in sessions]
+        assert title in titles, (
+            f"Session '{title}' not found in agent-deck. "
+            f"Found: {titles}"
+        )
+
+        # ── Step 3: done cleans up session ──────────────────
+        code, msg = done_command(
+            f"{feature}-{milestone}",
+            repo_root=repo_root,
+            force=True,
+        )
+        assert code == 0, f"done_command failed: {msg}"
+
+        # ── Step 4: Verify session removed ──────────────────
+        sessions = _agent_deck_sessions_json()
+        titles = [s.get("title", "") for s in sessions]
+        assert title not in titles, (
+            f"Session '{title}' still exists after done"
+        )
+
+    def test_impl_session_without_sandbox(
+        self, e2e_project: dict
+    ) -> None:
+        """--session works even without sandbox config."""
+        repo_root: Path = e2e_project["repo_root"]
+        feature = e2e_project["feature"]
+        milestone = e2e_project["milestone"]
+        title = f"{feature}/{milestone}"
+
+        # Remove infra.toml to disable sandbox
+        infra_toml = repo_root / ".devops-ai" / "infra.toml"
+        infra_backup = repo_root / ".devops-ai" / "infra.toml.bak"
+        infra_toml.rename(infra_backup)
+
+        # Ensure no leftover session
+        _agent_deck_remove(title)
+
+        try:
+            code, msg = impl_command(
+                f"{feature}/{milestone}",
+                repo_root=repo_root,
+                session=True,
+            )
+            assert code == 0, f"impl_command failed: {msg}"
+            assert "agent-deck session started" in msg.lower()
+            assert "no sandbox configured" in msg.lower()
+
+            # Verify session exists
+            sessions = _agent_deck_sessions_json()
+            titles = [s.get("title", "") for s in sessions]
+            assert title in titles
+        finally:
+            # Restore infra.toml and clean up
+            infra_backup.rename(infra_toml)
+            _agent_deck_remove(title)
+            # Clean up worktree
+            done_command(
+                f"{feature}-{milestone}",
+                repo_root=repo_root,
+                force=True,
+            )
+
+
+@pytest.mark.e2e
+class TestKworktreeSkill:
+    """Verify kworktree skill file structure."""
+
+    def _skill_path(self) -> Path:
+        """Locate the skill file relative to repo root."""
+        # Walk up from this test file to find repo root
+        anchor = Path(__file__).resolve().parent
+        for parent in (anchor, *anchor.parents):
+            candidate = parent / "skills" / "kworktree" / "SKILL.md"
+            if candidate.exists():
+                return candidate
+        pytest.fail("skills/kworktree/SKILL.md not found")
+
+    def test_skill_exists(self) -> None:
+        path = self._skill_path()
+        assert path.exists()
+
+    def test_all_commands_referenced(self) -> None:
+        content = self._skill_path().read_text()
+        for cmd in [
+            "kinfra init",
+            "kinfra spec",
+            "kinfra impl",
+            "kinfra done",
+            "kinfra status",
+            "kinfra worktrees",
+        ]:
+            assert cmd in content, f"Missing reference to '{cmd}'"
+
+    def test_observability_referenced(self) -> None:
+        content = self._skill_path().read_text()
+        assert "observability" in content.lower()
+        assert "46686" in content  # Jaeger UI port
+        assert "43000" in content  # Grafana port
+
+    def test_under_200_lines(self) -> None:
+        lines = self._skill_path().read_text().splitlines()
+        assert len(lines) < 200, f"Skill is {len(lines)} lines (max 200)"
+
+    def test_sandbox_aware_coding_section(self) -> None:
+        content = self._skill_path().read_text()
+        assert "sandbox" in content.lower()
+        assert "dynamic port" in content.lower() or "base_port" in content.lower()

--- a/tests/unit/test_agent_deck.py
+++ b/tests/unit/test_agent_deck.py
@@ -1,0 +1,203 @@
+"""Tests for agent-deck integration module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from devops_ai.agent_deck import (
+    add_session,
+    is_available,
+    remove_session,
+    send_to_session,
+    start_session,
+)
+
+
+class TestIsAvailable:
+    def setup_method(self) -> None:
+        """Reset the cached availability between tests."""
+        # Clear the lru_cache or module-level cache
+        is_available.cache_clear()
+
+    def test_found(self) -> None:
+        """shutil.which returns path → True."""
+        with patch(
+            "devops_ai.agent_deck.shutil.which",
+            return_value="/usr/bin/agent-deck",
+        ):
+            assert is_available() is True
+
+    def test_not_found(self) -> None:
+        """shutil.which returns None → False."""
+        with patch("devops_ai.agent_deck.shutil.which", return_value=None):
+            assert is_available() is False
+
+    def test_cached(self) -> None:
+        """Result is cached — shutil.which called only once."""
+        with patch(
+            "devops_ai.agent_deck.shutil.which",
+            return_value="/usr/bin/agent-deck",
+        ) as mock_which:
+            assert is_available() is True
+            assert is_available() is True
+            mock_which.assert_called_once()
+
+
+class TestAddSession:
+    def test_command(self) -> None:
+        """Verify correct command construction."""
+        with (
+            patch("devops_ai.agent_deck.is_available", return_value=True),
+            patch("devops_ai.agent_deck.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            add_session("my-feature/M1", group="dev", path="/tmp/worktree")
+
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert cmd == [
+                "agent-deck", "add", "my-feature/M1",
+                "--group", "dev",
+                "--path", "/tmp/worktree",
+            ]
+
+    def test_spec_naming(self) -> None:
+        """Spec feature → spec/<feature> in group dev."""
+        with (
+            patch("devops_ai.agent_deck.is_available", return_value=True),
+            patch("devops_ai.agent_deck.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            add_session("spec/wellness-reminders", group="dev", path="/tmp/wt")
+
+            cmd = mock_run.call_args[0][0]
+            assert cmd[2] == "spec/wellness-reminders"
+            assert cmd[4] == "dev"
+
+    def test_impl_naming(self) -> None:
+        """Impl feature/milestone → <feature>/<milestone> in group dev."""
+        with (
+            patch("devops_ai.agent_deck.is_available", return_value=True),
+            patch("devops_ai.agent_deck.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            add_session("wellness-reminders/M1", group="dev", path="/tmp/wt")
+
+            cmd = mock_run.call_args[0][0]
+            assert cmd[2] == "wellness-reminders/M1"
+            assert cmd[4] == "dev"
+
+
+class TestRemoveSession:
+    def test_command(self) -> None:
+        """Verify correct remove command."""
+        with (
+            patch("devops_ai.agent_deck.is_available", return_value=True),
+            patch("devops_ai.agent_deck.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            remove_session("my-feature/M1")
+
+            cmd = mock_run.call_args[0][0]
+            assert cmd == ["agent-deck", "remove", "my-feature/M1"]
+
+    def test_ignores_errors(self) -> None:
+        """subprocess fails → no exception raised."""
+        with (
+            patch("devops_ai.agent_deck.is_available", return_value=True),
+            patch("devops_ai.agent_deck.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=1, stderr="session not found"
+            )
+            # Should not raise
+            remove_session("nonexistent")
+
+
+class TestStartSession:
+    def test_command(self) -> None:
+        """Verify correct start command."""
+        with (
+            patch("devops_ai.agent_deck.is_available", return_value=True),
+            patch("devops_ai.agent_deck.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            start_session("my-feature/M1")
+
+            cmd = mock_run.call_args[0][0]
+            assert cmd == ["agent-deck", "session", "start", "my-feature/M1"]
+
+
+class TestSendToSession:
+    def test_command(self) -> None:
+        """Verify correct send command."""
+        with (
+            patch("devops_ai.agent_deck.is_available", return_value=True),
+            patch("devops_ai.agent_deck.subprocess.run") as mock_run,
+            patch("devops_ai.agent_deck.time.sleep"),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            msg = "/kmilestone my-feature/M1"
+            send_to_session("my-feature/M1", msg, delay=3)
+
+            cmd = mock_run.call_args[0][0]
+            assert cmd == [
+                "agent-deck", "session", "send",
+                "my-feature/M1", msg,
+            ]
+
+    def test_delay(self) -> None:
+        """Verify delay parameter is used."""
+        with (
+            patch("devops_ai.agent_deck.is_available", return_value=True),
+            patch("devops_ai.agent_deck.subprocess.run") as mock_run,
+            patch("devops_ai.agent_deck.time.sleep") as mock_sleep,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            send_to_session("title", "msg", delay=5)
+            mock_sleep.assert_called_once_with(5)
+
+    def test_default_delay(self) -> None:
+        """Default delay is 3 seconds."""
+        with (
+            patch("devops_ai.agent_deck.is_available", return_value=True),
+            patch("devops_ai.agent_deck.subprocess.run") as mock_run,
+            patch("devops_ai.agent_deck.time.sleep") as mock_sleep,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            send_to_session("title", "msg")
+            mock_sleep.assert_called_once_with(3)
+
+
+class TestSkipWhenUnavailable:
+    def test_all_ops_skip(self) -> None:
+        """Every function returns early when agent-deck not available."""
+        with (
+            patch("devops_ai.agent_deck.is_available", return_value=False),
+            patch("devops_ai.agent_deck.subprocess.run") as mock_run,
+        ):
+            add_session("title", group="dev", path="/tmp")
+            remove_session("title")
+            start_session("title")
+            send_to_session("title", "msg")
+            mock_run.assert_not_called()
+
+
+class TestSubprocessFailureWarns:
+    def test_warns_on_failure(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Subprocess failure → warning logged, no exception."""
+        with (
+            patch("devops_ai.agent_deck.is_available", return_value=True),
+            patch("devops_ai.agent_deck.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=1, stderr="something went wrong"
+            )
+            import logging
+
+            with caplog.at_level(logging.WARNING):
+                start_session("my-feature/M1")
+
+            assert "something went wrong" in caplog.text

--- a/tests/unit/test_agent_deck.py
+++ b/tests/unit/test_agent_deck.py
@@ -58,36 +58,46 @@ class TestAddSession:
             mock_run.assert_called_once()
             cmd = mock_run.call_args[0][0]
             assert cmd == [
-                "agent-deck", "add", "my-feature/M1",
-                "--group", "dev",
-                "--path", "/tmp/worktree",
+                "agent-deck", "add", "/tmp/worktree",
+                "-t", "my-feature/M1",
+                "-g", "dev",
             ]
 
     def test_spec_naming(self) -> None:
-        """Spec feature → spec/<feature> in group dev."""
+        """Spec feature → title=spec/<feature>, group=dev."""
         with (
             patch("devops_ai.agent_deck.is_available", return_value=True),
             patch("devops_ai.agent_deck.subprocess.run") as mock_run,
         ):
             mock_run.return_value = MagicMock(returncode=0, stderr="")
-            add_session("spec/wellness-reminders", group="dev", path="/tmp/wt")
+            add_session(
+                "spec/wellness-reminders",
+                group="dev",
+                path="/tmp/wt",
+            )
 
             cmd = mock_run.call_args[0][0]
-            assert cmd[2] == "spec/wellness-reminders"
-            assert cmd[4] == "dev"
+            # path is positional, title via -t, group via -g
+            assert cmd[2] == "/tmp/wt"
+            assert cmd[4] == "spec/wellness-reminders"
+            assert cmd[6] == "dev"
 
     def test_impl_naming(self) -> None:
-        """Impl feature/milestone → <feature>/<milestone> in group dev."""
+        """Impl feature/milestone → title=<feature>/<milestone>."""
         with (
             patch("devops_ai.agent_deck.is_available", return_value=True),
             patch("devops_ai.agent_deck.subprocess.run") as mock_run,
         ):
             mock_run.return_value = MagicMock(returncode=0, stderr="")
-            add_session("wellness-reminders/M1", group="dev", path="/tmp/wt")
+            add_session(
+                "wellness-reminders/M1",
+                group="dev",
+                path="/tmp/wt",
+            )
 
             cmd = mock_run.call_args[0][0]
-            assert cmd[2] == "wellness-reminders/M1"
-            assert cmd[4] == "dev"
+            assert cmd[4] == "wellness-reminders/M1"
+            assert cmd[6] == "dev"
 
 
 class TestRemoveSession:

--- a/tests/unit/test_cli_impl_session.py
+++ b/tests/unit/test_cli_impl_session.py
@@ -19,6 +19,14 @@ def _setup_git_repo(path: Path) -> None:
         ["git", "init"], cwd=path, capture_output=True, check=True
     )
     subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=path, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=path, check=True, capture_output=True,
+    )
+    subprocess.run(
         ["git", "commit", "--allow-empty", "-m", "init"],
         cwd=path,
         capture_output=True,
@@ -246,7 +254,7 @@ class TestSessionSendDelay:
             mock_lr.return_value = MagicMock(slots={})
             mock_ad.is_available.return_value = True
 
-            code, msg = impl_command(
+            impl_command(
                 "my-feature/M1",
                 repo_root=tmp_path,
                 session=True,

--- a/tests/unit/test_cli_impl_session.py
+++ b/tests/unit/test_cli_impl_session.py
@@ -1,0 +1,450 @@
+"""Tests for --session flag integration in impl and done commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from devops_ai.cli.done import done_command
+from devops_ai.cli.impl import impl_command
+
+# --- Helpers ---
+
+
+def _setup_git_repo(path: Path) -> None:
+    """Create a minimal git repo."""
+    import subprocess
+
+    subprocess.run(
+        ["git", "init"], cwd=path, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=path,
+        capture_output=True,
+        check=True,
+    )
+
+
+def _setup_milestone(
+    repo_root: Path, feature: str, milestone: str
+) -> None:
+    """Create a milestone file."""
+    impl_dir = (
+        repo_root / "docs" / "designs" / feature / "implementation"
+    )
+    impl_dir.mkdir(parents=True, exist_ok=True)
+    ms_file = impl_dir / f"{milestone}_foundation.md"
+    ms_file.write_text(f"# {milestone} Foundation\n")
+
+
+def _setup_infra_toml(repo_root: Path) -> None:
+    """Create a minimal infra.toml with sandbox config."""
+    devops_dir = repo_root / ".devops-ai"
+    devops_dir.mkdir(exist_ok=True)
+    (devops_dir / "infra.toml").write_text(
+        '[project]\nname = "test"\nprefix = "test"\n\n'
+        '[sandbox]\ncompose_file = "docker-compose.yml"\n\n'
+        "[sandbox.ports]\nAPI_PORT = 8080\n"
+    )
+
+
+def _mock_sandbox_setup() -> dict:
+    """Return a dict of patches for sandbox setup mocking."""
+    return {
+        "create_impl_worktree": "devops_ai.cli.impl.create_impl_worktree",
+        "load_registry": "devops_ai.cli.impl.load_registry",
+        "allocate_slot": "devops_ai.cli.impl.allocate_slot",
+        "clean_stale": "devops_ai.cli.impl.clean_stale_entries",
+        "claim_slot": "devops_ai.cli.impl.claim_slot",
+        "create_slot_dir": "devops_ai.cli.impl.create_slot_dir",
+        "copy_compose": "devops_ai.cli.impl.copy_compose_to_slot",
+        "gen_env": "devops_ai.cli.impl.generate_env_file",
+        "gen_override": "devops_ai.cli.impl.generate_override",
+        "start_sandbox": "devops_ai.cli.impl.start_sandbox",
+        "health_gate": "devops_ai.cli.impl.run_health_gate",
+    }
+
+
+class TestSessionFlagWithAgentDeck:
+    def test_all_three_calls_in_order(
+        self, tmp_path: Path
+    ) -> None:
+        """--session with agent-deck: add, start, send called."""
+        _setup_git_repo(tmp_path)
+        _setup_milestone(tmp_path, "my-feature", "M1")
+        _setup_infra_toml(tmp_path)
+        (tmp_path / "docker-compose.yml").write_text(
+            "services: {}\n"
+        )
+
+        wt_path = (
+            tmp_path.parent / f"{tmp_path.name}-impl-my-feature-M1"
+        )
+
+        with (
+            patch(
+                "devops_ai.cli.impl.create_impl_worktree",
+                return_value=wt_path,
+            ),
+            patch("devops_ai.cli.impl.load_registry") as mock_lr,
+            patch(
+                "devops_ai.cli.impl.allocate_slot",
+                return_value=(1, {"API_PORT": 8081}),
+            ),
+            patch("devops_ai.cli.impl.clean_stale_entries"),
+            patch("devops_ai.cli.impl.claim_slot"),
+            patch(
+                "devops_ai.cli.impl.create_slot_dir",
+                return_value=tmp_path / "slot",
+            ),
+            patch(
+                "devops_ai.cli.impl.copy_compose_to_slot",
+                return_value=tmp_path / "slot" / "docker-compose.yml",
+            ),
+            patch("devops_ai.cli.impl.generate_env_file"),
+            patch("devops_ai.cli.impl.generate_override"),
+            patch("devops_ai.cli.impl.start_sandbox"),
+            patch(
+                "devops_ai.cli.impl.run_health_gate",
+                return_value=True,
+            ),
+            patch(
+                "devops_ai.cli.impl.agent_deck"
+            ) as mock_ad,
+        ):
+            mock_lr.return_value = MagicMock(slots={})
+            mock_ad.is_available.return_value = True
+
+            code, msg = impl_command(
+                "my-feature/M1",
+                repo_root=tmp_path,
+                session=True,
+            )
+
+        assert code == 0
+        mock_ad.add_session.assert_called_once()
+        mock_ad.start_session.assert_called_once()
+        mock_ad.send_to_session.assert_called_once()
+
+        # Verify order: add → start → send
+        ad_calls = mock_ad.method_calls
+        call_names = [c[0] for c in ad_calls if c[0] != "is_available"]
+        assert call_names == [
+            "add_session", "start_session", "send_to_session"
+        ]
+
+
+class TestSessionFlagWithoutAgentDeck:
+    def test_warning_printed_impl_succeeds(
+        self, tmp_path: Path
+    ) -> None:
+        """--session without agent-deck: warning, but impl OK."""
+        _setup_git_repo(tmp_path)
+        _setup_milestone(tmp_path, "my-feature", "M1")
+        _setup_infra_toml(tmp_path)
+        (tmp_path / "docker-compose.yml").write_text(
+            "services: {}\n"
+        )
+
+        wt_path = (
+            tmp_path.parent / f"{tmp_path.name}-impl-my-feature-M1"
+        )
+
+        with (
+            patch(
+                "devops_ai.cli.impl.create_impl_worktree",
+                return_value=wt_path,
+            ),
+            patch("devops_ai.cli.impl.load_registry") as mock_lr,
+            patch(
+                "devops_ai.cli.impl.allocate_slot",
+                return_value=(1, {"API_PORT": 8081}),
+            ),
+            patch("devops_ai.cli.impl.clean_stale_entries"),
+            patch("devops_ai.cli.impl.claim_slot"),
+            patch(
+                "devops_ai.cli.impl.create_slot_dir",
+                return_value=tmp_path / "slot",
+            ),
+            patch(
+                "devops_ai.cli.impl.copy_compose_to_slot",
+                return_value=tmp_path / "slot" / "docker-compose.yml",
+            ),
+            patch("devops_ai.cli.impl.generate_env_file"),
+            patch("devops_ai.cli.impl.generate_override"),
+            patch("devops_ai.cli.impl.start_sandbox"),
+            patch(
+                "devops_ai.cli.impl.run_health_gate",
+                return_value=True,
+            ),
+            patch(
+                "devops_ai.cli.impl.agent_deck"
+            ) as mock_ad,
+        ):
+            mock_lr.return_value = MagicMock(slots={})
+            mock_ad.is_available.return_value = False
+
+            code, msg = impl_command(
+                "my-feature/M1",
+                repo_root=tmp_path,
+                session=True,
+            )
+
+        assert code == 0
+        assert "agent-deck not found" in msg.lower()
+        mock_ad.add_session.assert_not_called()
+
+
+class TestSessionSendDelay:
+    def test_delay_parameter_passed(
+        self, tmp_path: Path
+    ) -> None:
+        """send_to_session receives delay=3."""
+        _setup_git_repo(tmp_path)
+        _setup_milestone(tmp_path, "my-feature", "M1")
+        _setup_infra_toml(tmp_path)
+        (tmp_path / "docker-compose.yml").write_text(
+            "services: {}\n"
+        )
+
+        wt_path = (
+            tmp_path.parent / f"{tmp_path.name}-impl-my-feature-M1"
+        )
+
+        with (
+            patch(
+                "devops_ai.cli.impl.create_impl_worktree",
+                return_value=wt_path,
+            ),
+            patch("devops_ai.cli.impl.load_registry") as mock_lr,
+            patch(
+                "devops_ai.cli.impl.allocate_slot",
+                return_value=(1, {"API_PORT": 8081}),
+            ),
+            patch("devops_ai.cli.impl.clean_stale_entries"),
+            patch("devops_ai.cli.impl.claim_slot"),
+            patch(
+                "devops_ai.cli.impl.create_slot_dir",
+                return_value=tmp_path / "slot",
+            ),
+            patch(
+                "devops_ai.cli.impl.copy_compose_to_slot",
+                return_value=tmp_path / "slot" / "docker-compose.yml",
+            ),
+            patch("devops_ai.cli.impl.generate_env_file"),
+            patch("devops_ai.cli.impl.generate_override"),
+            patch("devops_ai.cli.impl.start_sandbox"),
+            patch(
+                "devops_ai.cli.impl.run_health_gate",
+                return_value=True,
+            ),
+            patch(
+                "devops_ai.cli.impl.agent_deck"
+            ) as mock_ad,
+        ):
+            mock_lr.return_value = MagicMock(slots={})
+            mock_ad.is_available.return_value = True
+
+            code, msg = impl_command(
+                "my-feature/M1",
+                repo_root=tmp_path,
+                session=True,
+            )
+
+        # Check delay=3 passed to send_to_session
+        send_call = mock_ad.send_to_session.call_args
+        assert send_call[1].get("delay") == 3 or (
+            len(send_call[0]) >= 3 and send_call[0][2] == 3
+        )
+
+
+class TestSessionSendCorrectCommand:
+    def test_kmilestone_command_sent(
+        self, tmp_path: Path
+    ) -> None:
+        """/kmilestone <feature>/<milestone> sent."""
+        _setup_git_repo(tmp_path)
+        _setup_milestone(tmp_path, "my-feature", "M1")
+        _setup_infra_toml(tmp_path)
+        (tmp_path / "docker-compose.yml").write_text(
+            "services: {}\n"
+        )
+
+        wt_path = (
+            tmp_path.parent / f"{tmp_path.name}-impl-my-feature-M1"
+        )
+
+        with (
+            patch(
+                "devops_ai.cli.impl.create_impl_worktree",
+                return_value=wt_path,
+            ),
+            patch("devops_ai.cli.impl.load_registry") as mock_lr,
+            patch(
+                "devops_ai.cli.impl.allocate_slot",
+                return_value=(1, {"API_PORT": 8081}),
+            ),
+            patch("devops_ai.cli.impl.clean_stale_entries"),
+            patch("devops_ai.cli.impl.claim_slot"),
+            patch(
+                "devops_ai.cli.impl.create_slot_dir",
+                return_value=tmp_path / "slot",
+            ),
+            patch(
+                "devops_ai.cli.impl.copy_compose_to_slot",
+                return_value=tmp_path / "slot" / "docker-compose.yml",
+            ),
+            patch("devops_ai.cli.impl.generate_env_file"),
+            patch("devops_ai.cli.impl.generate_override"),
+            patch("devops_ai.cli.impl.start_sandbox"),
+            patch(
+                "devops_ai.cli.impl.run_health_gate",
+                return_value=True,
+            ),
+            patch(
+                "devops_ai.cli.impl.agent_deck"
+            ) as mock_ad,
+        ):
+            mock_lr.return_value = MagicMock(slots={})
+            mock_ad.is_available.return_value = True
+
+            impl_command(
+                "my-feature/M1",
+                repo_root=tmp_path,
+                session=True,
+            )
+
+        send_call = mock_ad.send_to_session.call_args
+        # First positional arg is title, second is message
+        assert send_call[0][1] == "/kmilestone my-feature/M1"
+
+
+class TestDoneRemovesSession:
+    def test_remove_called(self, tmp_path: Path) -> None:
+        """done calls agent_deck.remove_session."""
+        _setup_git_repo(tmp_path)
+        _setup_infra_toml(tmp_path)
+
+        mock_wt = MagicMock()
+        mock_wt.feature = "my-feature-M1"
+        mock_wt.wt_type = "impl"
+        mock_wt.path = tmp_path / "wt"
+
+        mock_slot = MagicMock()
+        mock_slot.slot_dir = str(tmp_path / "slot")
+        mock_slot.slot_id = 1
+
+        with (
+            patch(
+                "devops_ai.cli.done.list_worktrees",
+                return_value=[mock_wt],
+            ),
+            patch(
+                "devops_ai.cli.done.check_dirty",
+                return_value=MagicMock(is_dirty=False),
+            ),
+            patch(
+                "devops_ai.cli.done.load_registry"
+            ) as mock_lr,
+            patch(
+                "devops_ai.cli.done.get_slot_for_worktree",
+                return_value=mock_slot,
+            ),
+            patch("devops_ai.cli.done.stop_sandbox"),
+            patch("devops_ai.cli.done.remove_slot_dir"),
+            patch("devops_ai.cli.done.release_slot"),
+            patch("devops_ai.cli.done.remove_worktree"),
+            patch("devops_ai.cli.done.agent_deck") as mock_ad,
+        ):
+            mock_lr.return_value = MagicMock()
+            (tmp_path / "slot").mkdir(exist_ok=True)
+
+            code, msg = done_command(
+                "my-feature-M1", repo_root=tmp_path
+            )
+
+        assert code == 0
+        mock_ad.remove_session.assert_called_once_with(
+            "my-feature-M1"
+        )
+
+
+class TestDoneNoAgentDeckSkips:
+    def test_succeeds_without_agent_deck(
+        self, tmp_path: Path
+    ) -> None:
+        """done succeeds when agent-deck not available."""
+        _setup_git_repo(tmp_path)
+        _setup_infra_toml(tmp_path)
+
+        mock_wt = MagicMock()
+        mock_wt.feature = "my-feature-M1"
+        mock_wt.wt_type = "impl"
+        mock_wt.path = tmp_path / "wt"
+
+        with (
+            patch(
+                "devops_ai.cli.done.list_worktrees",
+                return_value=[mock_wt],
+            ),
+            patch(
+                "devops_ai.cli.done.check_dirty",
+                return_value=MagicMock(is_dirty=False),
+            ),
+            patch(
+                "devops_ai.cli.done.load_registry"
+            ) as mock_lr,
+            patch(
+                "devops_ai.cli.done.get_slot_for_worktree",
+                return_value=None,
+            ),
+            patch("devops_ai.cli.done.remove_worktree"),
+            patch("devops_ai.cli.done.agent_deck") as mock_ad,
+        ):
+            mock_lr.return_value = MagicMock()
+            mock_ad.is_available.return_value = False
+
+            code, msg = done_command(
+                "my-feature-M1", repo_root=tmp_path
+            )
+
+        assert code == 0
+        mock_ad.remove_session.assert_not_called()
+
+
+class TestSessionWithSpec:
+    def test_session_works_without_sandbox(
+        self, tmp_path: Path
+    ) -> None:
+        """--session works for worktree-only (no sandbox)."""
+        _setup_git_repo(tmp_path)
+        _setup_milestone(tmp_path, "my-feature", "M1")
+        # No infra.toml → no sandbox
+
+        wt_path = (
+            tmp_path.parent / f"{tmp_path.name}-impl-my-feature-M1"
+        )
+
+        with (
+            patch(
+                "devops_ai.cli.impl.create_impl_worktree",
+                return_value=wt_path,
+            ),
+            patch(
+                "devops_ai.cli.impl.agent_deck"
+            ) as mock_ad,
+        ):
+            mock_ad.is_available.return_value = True
+
+            code, msg = impl_command(
+                "my-feature/M1",
+                repo_root=tmp_path,
+                session=True,
+            )
+
+        assert code == 0
+        # Session should still be created even without sandbox
+        mock_ad.add_session.assert_called_once()
+        mock_ad.start_session.assert_called_once()
+        mock_ad.send_to_session.assert_called_once()


### PR DESCRIPTION
## Summary

- **Agent-deck module** (`src/devops_ai/agent_deck.py`): Graceful-degradation wrapper around the `agent-deck` CLI for AI coding session management (add/remove/start/send), with `lru_cache` availability check
- **`--session` flag** on `kinfra impl`: Automatically creates an agent-deck session (add → start → send `/kmilestone`), with cleanup in `kinfra done` via branch-name-derived session title
- **kworktree skill** (`skills/kworktree/SKILL.md`): 167-line reference for AI coding tools covering all kinfra commands, sandbox-aware coding, and observability endpoints
- **E2E bug fixes**: Real E2E testing against live `agent-deck` caught and fixed wrong CLI arg format in `add_session` and session title mismatch (hyphen vs slash) in `done_command`

## Test plan

- [x] 172 unit tests pass (14 agent-deck + 12 session flag + 5 title derivation)
- [x] 7 E2E tests pass (real agent-deck session lifecycle + skill structure verification)
- [x] Ruff lint + Mypy type checks clean
- [x] No regressions in M1-M3 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)