### PR TITLE
feat(M1): kinfra init --dry-run, --auto, --health-endpoint flags

### DIFF
--- a/docs/designs/kinfra-onboard/ARCHITECTURE.md
+++ b/docs/designs/kinfra-onboard/ARCHITECTURE.md
@@ -1,0 +1,227 @@
+# kinfra-onboard: Architecture
+
+## Overview
+
+kinfra-onboard is a Claude Code skill (SKILL.md) that orchestrates project onboarding to the kinfra ecosystem. It has two deliverables: (1) the skill itself, and (2) `--dry-run` and `--auto` flags added to `kinfra init` so the skill can drive it programmatically.
+
+The skill is the intelligence layer — it reads the project, assesses safety, decides what to do, presents a plan, and handles adaptive changes. `kinfra init` remains the deterministic tool that owns compose rewriting and `infra.toml` generation.
+
+## Component Diagram
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Claude Code session                                │
+│                                                     │
+│  ┌───────────────────────────────────────────────┐  │
+│  │  /kinfra-onboard skill (SKILL.md)             │  │
+│  │                                               │  │
+│  │  Phase 1: Analyze                             │  │
+│  │    ├─ read compose, project.md, app config    │  │
+│  │    ├─ check git state                         │  │
+│  │    ├─ detect existing kinfra config           │  │
+│  │    └─ report findings                         │  │
+│  │                                               │  │
+│  │  Phase 2: Propose                             │  │
+│  │    ├─ run: kinfra init --dry-run --auto       │  │
+│  │    ├─ identify app-level OTEL changes         │  │
+│  │    └─ present full plan to user               │  │
+│  │                                               │  │
+│  │  Phase 3: Execute                             │  │
+│  │    ├─ run: kinfra init --auto                 │  │
+│  │    ├─ adapt app OTEL config                   │  │
+│  │    ├─ update project.md                       │  │
+│  │    └─ update relevant docs/skills             │  │
+│  │                                               │  │
+│  │  Phase 4: Verify & Commit                     │  │
+│  │    ├─ validate infra.toml                     │  │
+│  │    ├─ validate compose parses                 │  │
+│  │    ├─ check config consistency                │  │
+│  │    └─ git commit                              │  │
+│  └───────────────────────────────────────────────┘  │
+│           │                                         │
+│           │ shell: kinfra init --dry-run --auto     │
+│           │ shell: kinfra init --auto               │
+│           ▼                                         │
+│  ┌───────────────────────────────────────────────┐  │
+│  │  kinfra CLI (existing + new flags)            │  │
+│  │                                               │  │
+│  │  init_cmd.py                                  │  │
+│  │    ├─ --dry-run: preview changes to stdout    │  │
+│  │    ├─ --auto: accept defaults, no prompts     │  │
+│  │    ├─ detect project name                     │  │
+│  │    ├─ find/parse compose                      │  │
+│  │    ├─ identify obs services                   │  │
+│  │    ├─ generate infra.toml                     │  │
+│  │    └─ rewrite compose (parameterize + comment)│  │
+│  └───────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+### Component Relationships (Structured Summary)
+
+| Component | Type | Depends On | Used By |
+|-----------|------|------------|---------|
+| SKILL.md (kinfra-onboard) | Skill file | kinfra CLI, project files | Claude Code user |
+| kinfra init --dry-run | CLI flag | init_cmd.py internals | Skill Phase 2 |
+| kinfra init --auto | CLI flag | init_cmd.py internals | Skill Phase 3 |
+| init_cmd.py | Python module | compose.py, config.py | CLI entry point, skill |
+
+## Components
+
+### SKILL.md (kinfra-onboard skill)
+
+**Location:** `skills/kinfra-onboard/SKILL.md`
+**Purpose:** Instructs Claude Code how to run the phased onboarding workflow.
+**Key behaviors:**
+- Phase 1 (Analyze): Read project files, check safety, report findings
+- Phase 2 (Propose): Run `kinfra init --dry-run --auto`, identify OTEL changes, present plan
+- Phase 3 (Execute): Run `kinfra init --auto`, make app-level changes, update project.md
+- Phase 4 (Verify & Commit): Validate results, create git commit
+- --check mode: Run Phase 1 only, skip the rest
+
+**Interface:** Invoked as `/kinfra-onboard [--check]`
+
+### kinfra init --dry-run flag
+
+**Location:** `src/devops_ai/cli/init_cmd.py`
+**Purpose:** Preview all changes kinfra init would make without writing any files.
+**Key behaviors:**
+- Runs the full detection pipeline (project name, compose, services, ports, obs services)
+- Prints what infra.toml would contain
+- Prints what compose changes would be made (port parameterization, commented services)
+- Exits without writing anything
+
+### kinfra init --auto flag
+
+**Location:** `src/devops_ai/cli/init_cmd.py`
+**Purpose:** Accept all defaults and skip interactive prompts.
+**Key behaviors:**
+- Uses detected project name without prompting
+- Uses first compose file found without prompting
+- Uses default health endpoint `/api/v1/health` without prompting
+- Uses project name as worktree prefix without prompting
+- Auto-confirms config update if existing config found
+- All other logic identical to interactive mode
+
+## Data Flow
+
+```
+User: /kinfra-onboard
+        │
+        ▼
+Phase 1: ANALYZE
+        │
+        ├─ read .devops-ai/project.md
+        ├─ read .devops-ai/infra.toml (if exists → already onboarded?)
+        ├─ read docker-compose*.yml
+        ├─ read app config files (config.yaml, .env, etc.)
+        ├─ run: git status --porcelain
+        ├─ run: docker compose config (validate compose)
+        │
+        ▼
+   Report findings to user
+        │
+        ▼
+Phase 2: PROPOSE
+        │
+        ├─ run: kinfra init --dry-run --auto
+        │       └─ captures stdout: planned infra.toml + compose changes
+        ├─ identify OTEL endpoint in app config
+        ├─ identify docs/skills referencing local obs
+        │
+        ▼
+   Present full change plan to user
+        │
+   ── user approves? ──
+        │ yes              │ no
+        ▼                  ▼
+Phase 3: EXECUTE        (abort)
+        │
+        ├─ run: kinfra init --auto
+        │       └─ writes infra.toml, rewrites compose
+        ├─ edit app OTEL config (endpoint → shared stack)
+        ├─ edit project.md (add Infrastructure section)
+        ├─ edit docs/skills referencing local obs endpoints
+        │
+        ▼
+Phase 4: VERIFY & COMMIT
+        │
+        ├─ validate: infra.toml exists and parses
+        ├─ validate: docker compose config (compose still valid)
+        ├─ validate: OTEL endpoint references consistent
+        ├─ run: git add <changed files>
+        ├─ run: git commit -m "chore: onboard to kinfra sandbox and shared observability"
+        │
+        ▼
+   Report summary to user
+```
+
+**Flow Steps (Structured Summary):**
+
+1. Skill reads project files (compose, project.md, app config, git status)
+2. Skill reports findings and checks for blockers (dirty git, no compose, already onboarded)
+3. Skill runs `kinfra init --dry-run --auto` to preview deterministic changes
+4. Skill identifies additional adaptive changes needed (OTEL endpoints, docs)
+5. Skill presents combined plan to user for approval
+6. On approval: skill runs `kinfra init --auto` for deterministic changes
+7. Skill makes adaptive changes (edit app config, project.md, docs)
+8. Skill validates all changes (config parses, compose valid, references consistent)
+9. Skill creates git commit with all changes
+
+## State Management
+
+| State | Where | Lifecycle |
+|-------|-------|-----------|
+| Project analysis results | Skill conversation context | Created in Phase 1, used through Phase 4 |
+| kinfra init dry-run output | Captured stdout | Created in Phase 2, presented to user |
+| Changed file list | Skill conversation context | Accumulated in Phase 3, used for git commit in Phase 4 |
+| .devops-ai/infra.toml | Project filesystem | Created by kinfra init in Phase 3 |
+| docker-compose.yml.bak | Project filesystem | Created by kinfra init in Phase 3 (backup) |
+
+## Error Handling
+
+| Situation | Phase | Behavior |
+|-----------|-------|----------|
+| No compose file found | 1 (Analyze) | Report, offer worktree-only setup (infra.toml with has_sandbox=false) |
+| Dirty git state | 1 (Analyze) | Warn, recommend commit/stash, pause for user decision |
+| Already onboarded | 1 (Analyze) | Report current state, offer re-run if user suspects drift |
+| kinfra not installed | 2 (Propose) | Error with instructions to run install.sh |
+| kinfra init --dry-run fails | 2 (Propose) | Show error output, abort with explanation |
+| Compose doesn't parse after changes | 4 (Verify) | Restore from .bak, report failure |
+| OTEL config format not recognized | 2 (Propose) | Surface to user: "I found OTEL config at X but I'm not sure how to update it. Here's what I see — how should this change?" |
+| User denies proposal | 2 (Propose) | Abort cleanly, no changes made |
+
+## Integration Points
+
+| Component | Current State | Change Needed |
+|-----------|---------------|---------------|
+| `init_cmd.py` | Interactive only (typer.prompt/confirm) | Add `--dry-run` and `--auto` flags |
+| `init_command()` function | Returns exit code, writes directly | Refactor: extract detection into pure functions, add dry-run path |
+| `install.sh` | Symlinks skills/ to tool dirs | Will pick up new skill automatically (no change needed) |
+| `project.md` (target project) | May or may not have Infrastructure section | Skill adds/updates Infrastructure section in Phase 3 |
+
+## Verification Approach
+
+| Component | How to Verify |
+|-----------|---------------|
+| `--dry-run` flag | Unit test: runs detection, produces output, writes no files |
+| `--auto` flag | Unit test: runs without stdin, uses defaults, produces same result as interactive with defaults accepted |
+| `--dry-run --auto` combined | Unit test: produces preview output, writes nothing |
+| SKILL.md | Manual: run `/kinfra-onboard` on khealth, verify phased flow |
+| --check mode | Manual: run `/kinfra-onboard --check` on onboarded and non-onboarded projects |
+
+## Implementation Planning Summary
+
+### New Components to Create
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| kinfra-onboard skill | `skills/kinfra-onboard/SKILL.md` | Phased onboarding workflow instructions for Claude Code |
+
+### Existing Components to Modify
+
+| Component | Location | Changes Required |
+|-----------|----------|------------------|
+| init_cmd.py | `src/devops_ai/cli/init_cmd.py` | Add `--dry-run` and `--auto` flags to init_command(); refactor detection logic into reusable functions; add dry-run output formatting |
+| main.py (CLI) | `src/devops_ai/cli/main.py` | Wire new flags through to init_command() |
+| install.sh | `install.sh` | No change needed — auto-discovers skills/ |

--- a/docs/designs/kinfra-onboard/DESIGN.md
+++ b/docs/designs/kinfra-onboard/DESIGN.md
@@ -1,0 +1,90 @@
+# kinfra-onboard: Design
+
+## Problem Statement
+
+Onboarding a project to the kinfra ecosystem (sandbox isolation, shared observability) requires understanding the project's current setup, making judgment calls about what's safe to change, running `kinfra init`, and then adapting app-level configuration that kinfra can't touch. Today this is a manual, project-specific process that requires knowing both kinfra internals and the target project's architecture.
+
+## Goals
+
+- A developer can run `/kinfra-onboard` in any project and get an intelligent, phased onboarding experience
+- The skill assesses project readiness and safety before making changes
+- The deterministic work (compose parameterization, config generation) stays in `kinfra init`
+- The adaptive work (OTEL rewiring, app config changes, documentation updates) is handled by the skill with project-specific understanding
+- The user approves each phase before the skill proceeds
+
+## Non-Goals (Out of Scope)
+
+- Replacing `kinfra init` — it remains a standalone CLI tool humans can run directly
+- Handling production deployments or CI/CD changes
+- Onboarding projects that don't use Docker Compose at all (kinfra requires it)
+- Auto-fixing broken Docker setups — the skill assesses and reports, doesn't repair unrelated issues
+
+## User Experience
+
+### Scenario 1: Fresh project with local observability (khealth)
+
+User runs `/kinfra-onboard` in a project that has a docker-compose.yml with app services and a local Jaeger instance. The skill:
+
+1. **Phase 1 — Analyze:** Reads compose, app config, project.md. Reports what it found: "wellness-agent on port 8080, local Jaeger on 14686/14317, OTEL configured in config.yaml pointing to http://jaeger:4317. Git is clean."
+2. **Phase 2 — Propose:** "I'll run `kinfra init --dry-run` to preview compose changes, then show you what app config needs updating." Shows the dry-run output and its own plan for OTEL rewiring. User approves.
+3. **Phase 3 — Execute:** Runs `kinfra init --auto`, updates the app's OTEL endpoint config to use the shared stack, updates relevant docs/skills. Reports what changed.
+4. **Phase 4 — Verify:** Confirms `infra.toml` is valid, compose still parses, app config is consistent.
+
+### Scenario 2: Project already onboarded
+
+User runs `/kinfra-onboard` in a project that already has `.devops-ai/infra.toml` and a kinfra-managed compose file. The skill detects this and reports: "This project is already onboarded to kinfra. Config looks current. Nothing to do." Offers to re-run analysis if the user suspects drift.
+
+### Scenario 3: Project with no compose file
+
+User runs `/kinfra-onboard` in a project with no Docker infrastructure. The skill reports: "No docker-compose.yml found. kinfra requires Docker Compose for sandbox management. You can still use kinfra for worktree management (spec/impl) without sandboxes." Offers to generate a minimal `infra.toml` with `has_sandbox = false`.
+
+### Scenario 4: Dirty git state
+
+User runs `/kinfra-onboard` in a project with uncommitted changes. The skill warns: "There are uncommitted changes. Onboarding modifies docker-compose.yml and possibly app config files. I recommend committing or stashing first so changes are easy to review and revert." Pauses for user decision.
+
+### Scenario 5: Complex compose with non-standard observability
+
+User runs `/kinfra-onboard` in a project that has a custom Prometheus config, Grafana dashboards, or an observability setup that doesn't match the standard image patterns. The skill identifies what it recognizes and what it doesn't, surfaces uncertainty: "I see a `monitoring` service using `prom/prometheus` — that matches kinfra's shared stack. But there's also a `metrics-collector` service I can't classify. Want me to treat it as an app service (keep it) or observability (comment it out)?"
+
+## Key Decisions
+
+### Decision 1: Skill drives kinfra, not the other way around
+**Choice:** The skill is the intelligent orchestrator; `kinfra init` is the mechanical tool it calls.
+**Alternatives considered:** Making kinfra init smarter itself; having the skill bypass kinfra entirely.
+**Rationale:** Clean separation — kinfra stays deterministic and testable, the skill provides the judgment layer. Humans can still use `kinfra init` directly.
+
+### Decision 2: Phased execution with user checkpoints
+**Choice:** Four phases (Analyze, Propose, Execute, Verify) with user approval between Propose and Execute.
+**Alternatives considered:** Single-pass execution; fully interactive question-by-question flow.
+**Rationale:** Onboarding is a trust-building moment. Users want to see what will happen before it happens, but don't want to answer 15 individual questions.
+
+### Decision 3: kinfra init gets --dry-run and --auto flags
+**Choice:** Add `--dry-run` (preview without writing) and `--auto` (accept all defaults, non-interactive) to `kinfra init`.
+**Alternatives considered:** Having the skill call kinfra's Python functions directly; generating infra.toml from the skill.
+**Rationale:** `--dry-run` lets the skill preview and present changes. `--auto` lets it execute without interactive prompts. Both flags are useful for humans too. kinfra stays the single owner of compose rewriting logic.
+
+### Decision 4: The skill handles app-level OTEL rewiring
+**Choice:** The skill reads and modifies app config (e.g., config.yaml OTEL endpoint) to point at the shared stack.
+**Alternatives considered:** Having kinfra handle this via infra.toml; leaving it as a manual step.
+**Rationale:** OTEL config varies widely across projects (YAML config, env vars, code constants). An LLM skill can understand and adapt to any format. kinfra can't reasonably handle this generically.
+
+### Decision 5: Safety assessment before any changes
+**Choice:** The skill checks git state, compose validity, and existing kinfra config before proposing changes.
+**Alternatives considered:** Just running kinfra init and handling errors.
+**Rationale:** It's better to surface problems before making changes than to roll back after. The backup (.yml.bak) is a safety net, not the primary strategy.
+
+### Decision 6: Update project.md after onboarding
+**Choice:** Yes — the skill updates `.devops-ai/project.md` to add/update the Infrastructure section with kinfra commands.
+**Rationale:** Keeps project.md as the single source of truth for how to work with the project. Other skills (ktask, kmilestone) read Infrastructure config from there.
+
+### Decision 7: Support --check mode
+**Choice:** `/kinfra-onboard --check` runs Phase 1 (Analyze) only and reports status without proposing changes.
+**Rationale:** Useful for verifying onboarding state, detecting drift, or just understanding a project's current setup before committing to changes.
+
+### Decision 8: Git commit after onboarding
+**Choice:** Yes — the skill creates a commit with all onboarding changes after successful execution.
+**Rationale:** Makes the onboarding a single, reviewable, revertable unit of change. The commit happens after verification, so it only captures a known-good state.
+
+## Open Questions
+
+- How should the skill handle projects that use `docker compose` profiles (e.g., `--profile observability`)? Defer until encountered.

--- a/docs/designs/kinfra-onboard/SCENARIOS.md
+++ b/docs/designs/kinfra-onboard/SCENARIOS.md
@@ -1,0 +1,165 @@
+# Design Validation: kinfra-onboard
+
+**Date:** 2026-02-12
+**Documents Validated:**
+- Design: DESIGN.md
+- Architecture: ARCHITECTURE.md
+
+## Validation Summary
+
+**Scenarios Validated:** 12 traced
+**Critical Gaps Found:** 7 (all resolved)
+**Interface Contracts:** kinfra init CLI flags, SKILL.md phases
+
+## Key Decisions Made
+
+1. **OTEL endpoint after onboarding:** Set app config to `http://localhost:44317` (shared stack host port). Sandbox overrides via env var. Apps with graceful degradation (like khealth) handle unreachable endpoints safely.
+   - Context: GAP-1 — after commenting out local Jaeger, what endpoint to use?
+   - Trade-off: Assumes shared observability stack is running for local dev tracing.
+
+2. **kinfra init failure handling:** Skill reports the error, explains what went wrong, and makes a decision with the user. Does not silently work around kinfra.
+   - Context: GAP-2 — what if kinfra init --dry-run or --auto fails?
+   - Trade-off: User must be involved when things go wrong, no fully automated recovery.
+
+3. **Rollback on verification failure:** Full rollback — restore compose from .bak, delete generated infra.toml, `git checkout` any skill-edited files. Commit hasn't happened yet so this is clean.
+   - Context: GAP-3 — scope of undo if Phase 4 verification fails.
+
+4. **Selective git staging:** Skill tracks which files it changed through Phase 3, stages only those files explicitly. Never uses `git add -A`.
+   - Context: GAP-4 — dirty git + onboarding commit shouldn't capture unrelated changes.
+
+5. **Re-onboarding:** `--auto` auto-confirms update on existing config. Compose rewriting already skips parameterized ports. Needs a test.
+   - Context: GAP-5 — what happens when user re-runs on already-onboarded project.
+
+6. **Don't edit Python source:** Skill updates config files (YAML, env, etc.) not hardcoded Python defaults. If OTEL is only in source code with no config mechanism, surface to user and discuss.
+   - Context: GAP-6 — OTEL endpoint hardcoded in Python instead of config file.
+
+7. **Health endpoint override flag:** Add `--health-endpoint` to `kinfra init` so `--auto` can pass the correct value detected by the skill, rather than always defaulting to `/api/v1/health`.
+   - Context: GAP-7 — `--auto` default wrong for many projects.
+
+## Interface Contracts
+
+### kinfra init CLI (updated)
+
+```
+kinfra init [--dry-run] [--auto] [--health-endpoint TEXT]
+```
+
+| Flag | Behavior |
+|------|----------|
+| (none) | Current interactive mode, unchanged |
+| `--dry-run` | Run full detection pipeline, print planned changes to stdout, write nothing |
+| `--auto` | Accept all detected defaults, no prompts. Auto-confirm update if config exists. |
+| `--dry-run --auto` | Preview with defaults, no prompts, write nothing |
+| `--health-endpoint` | Override health endpoint (default: `/api/v1/health`). Useful with `--auto`. |
+
+**--dry-run output format:**
+
+```
+Project: wellness-agent
+Prefix: wellness-agent
+Compose: docker-compose.yml
+
+Services detected:
+  wellness-agent: ports [8080]
+  jaeger: ports [14686, 14317] (observability — will be commented out)
+
+Planned infra.toml:
+  [project]
+  name = "wellness-agent"
+  ...
+
+Compose changes:
+  - Parameterize port 8080 → ${WELLNESS_AGENT_WELLNESS_AGENT_PORT:-8080}
+  - Comment out service: jaeger
+  - Remove depends_on: jaeger from wellness-agent
+  - Add kinfra header comment
+  - Backup: docker-compose.yml.bak
+
+No files written (dry run).
+```
+
+### Skill Phase Contracts
+
+**Phase 1 output (to user):**
+```
+## Project Analysis
+
+- **Project:** wellness-agent (from .devops-ai/project.md)
+- **Git state:** Clean
+- **Compose:** docker-compose.yml (2 services)
+  - wellness-agent: port 8080, health check at /api/v1/health
+  - jaeger: ports 14686, 14317 (observability — shared stack replaces this)
+- **OTEL config:** config.yaml → endpoint: "http://jaeger:4317"
+- **kinfra status:** Not onboarded (no infra.toml)
+```
+
+**Phase 2 output (to user):**
+```
+## Proposed Changes
+
+**kinfra init will:**
+[dry-run output from above]
+
+**I will also:**
+- Update config.yaml: OTEL endpoint → http://localhost:44317
+- Update .devops-ai/project.md: Add Infrastructure section
+- Update any docs/skills referencing local Jaeger ports
+
+Proceed?
+```
+
+**Phase 3 tracked file list:**
+```
+Files changed:
+- .devops-ai/infra.toml (created by kinfra init)
+- docker-compose.yml (rewritten by kinfra init)
+- docker-compose.yml.bak (backup, not committed)
+- config.yaml (OTEL endpoint updated by skill)
+- .devops-ai/project.md (Infrastructure section added by skill)
+```
+
+**Phase 4 verification checks:**
+1. `.devops-ai/infra.toml` exists and parses as valid TOML with required fields
+2. `docker compose config` succeeds (or: compose file parses as valid YAML)
+3. OTEL endpoint references point to shared stack (no references to old local Jaeger)
+4. On success: `git add <tracked files>` + `git commit`
+5. On failure: restore .bak, delete infra.toml, `git checkout` edited files
+
+## Recommended Milestone Structure
+
+### Milestone 1: kinfra init --dry-run and --auto flags
+
+**User Story:** A developer or script can run `kinfra init --dry-run --auto` to preview onboarding changes without interaction.
+
+**Scope:**
+- `init_cmd.py`: Refactor `init_command()` to separate detection from interaction from writing. Add `--dry-run`, `--auto`, and `--health-endpoint` flags.
+- `main.py`: Wire flags through to `init_command()`.
+- Tests: Unit tests for --dry-run (no files written), --auto (no prompts), combined mode.
+
+**E2E Test:**
+```
+Given: A project directory with docker-compose.yml containing app + Jaeger services
+When: kinfra init --dry-run --auto
+Then: stdout shows planned infra.toml and compose changes, no files are created or modified
+```
+
+**Depends On:** Nothing
+
+---
+
+### Milestone 2: kinfra-onboard skill
+
+**User Story:** A developer runs `/kinfra-onboard` in any project and gets a phased, intelligent onboarding experience.
+
+**Scope:**
+- `skills/kinfra-onboard/SKILL.md`: Full skill document with Phase 1-4 instructions, --check mode, error handling, OTEL rewiring guidance.
+- Manual validation on khealth as the first real target.
+
+**E2E Test:**
+```
+Given: khealth project (compose with app + Jaeger, OTEL config, clean git)
+When: /kinfra-onboard
+Then: All 4 phases complete — infra.toml created, compose rewritten, OTEL updated, project.md updated, git commit created
+```
+
+**Depends On:** Milestone 1 (skill calls kinfra init --dry-run --auto)

--- a/docs/designs/kinfra-onboard/implementation/HANDOFF_M1.md
+++ b/docs/designs/kinfra-onboard/implementation/HANDOFF_M1.md
@@ -1,0 +1,25 @@
+# Handoff — M1: kinfra init --dry-run and --auto
+
+## Task 1.1 Complete: Refactor init_command() to separate detection from interaction
+
+**Approach:** Created `InitPlan` dataclass and `detect_project(project_root) -> InitPlan` pure function. Extracted compose finding, service parsing, obs identification, name detection, port mapping, and toml generation into the pipeline.
+
+**Gotcha:** `init_command()` still re-parses compose after interactive overrides (user may pick a different compose file or prefix, changing port var names). The plan from `detect_project()` is used for display, but final values are rebuilt from user input. Task 1.2 will need to handle this — in `--auto` mode, use `detect_project()` output directly; in interactive mode, rebuild after prompts.
+
+**Next Task Notes:** Task 1.2 adds `--dry-run`, `--auto`, `--health-endpoint` flags. The `detect_project()` return value has everything needed for dry-run output and auto execution. Wire new params into `init_command()` signature and add branching logic: dry_run → format+print plan; auto → skip prompts and use plan directly.
+
+## Task 1.2 Complete: Add --dry-run, --auto, and --health-endpoint flags
+
+**Approach:** Three new params on `init_command()`. `--auto` uses `detect_project()` plan directly (no prompts, no rebuild). `--dry-run` formats plan with `_format_dry_run_output()` and exits. `--health-endpoint` overrides plan.health_endpoint and regenerates toml. Interactive mode falls through to existing prompt-based flow.
+
+**Gotcha:** When `--auto` and existing config coexist, we auto-confirm the update (skip `typer.confirm`). The `--dry-run` without `--auto` still prompts for values, then previews with the user-provided overrides (builds a temporary `overridden_plan`).
+
+**Next Task Notes:** Task 1.3 is VALIDATION — run `kinfra init --dry-run --auto` and `kinfra init --auto` against a real temp project directory. Test the CLI end-to-end via shell commands.
+
+## Task 1.3 Complete: E2E verification
+
+**E2E test: cli/init-flags-validation — 5 steps — PASSED**
+
+**Gotcha:** Test project pyproject.toml needs `version` field — `uv` validates the pyproject in the cwd even when running a globally-installed tool. Minimal `[project]\nname = "x"` fails; needs `version = "0.1.0"`.
+
+**Note:** The `--auto` re-run on existing config doesn't re-parameterize compose ports (they're already parameterized from first run), so compose rewrite is skipped silently. This is correct behavior — `rewrite_compose` sees `${` in port specs and skips them.

--- a/docs/designs/kinfra-onboard/implementation/M1_init_flags.md
+++ b/docs/designs/kinfra-onboard/implementation/M1_init_flags.md
@@ -1,0 +1,227 @@
+---
+design: ../DESIGN.md
+architecture: ../ARCHITECTURE.md
+---
+
+# Milestone 1: kinfra init --dry-run and --auto
+
+**Goal:** `kinfra init` supports `--dry-run`, `--auto`, and `--health-endpoint` flags, enabling non-interactive and preview modes.
+
+---
+
+## Task 1.1: Refactor init_command() to separate detection from interaction
+
+**File(s):** `src/devops_ai/cli/init_cmd.py`
+**Type:** CODING
+**Estimated time:** 1-2 hours
+
+**Description:**
+Extract the detection pipeline from `init_command()` into a pure function that returns a structured result, separate from the interactive prompts and file writing. This enables --dry-run and --auto to reuse the same detection logic.
+
+**Implementation Notes:**
+
+Create a dataclass `InitPlan` that holds all detected/decided values:
+```python
+@dataclass
+class InitPlan:
+    project_root: Path
+    project_name: str
+    prefix: str
+    compose_file: str
+    compose_path: Path
+    services: dict[str, dict[str, Any]]
+    obs_services: list[str]
+    app_services: dict[str, dict[str, Any]]
+    ports: dict[str, int]
+    health_endpoint: str | None
+    health_port_var: str | None
+    toml_content: str  # generated infra.toml string
+```
+
+Extract a `detect_project(project_root: Path) -> InitPlan` function that:
+1. Finds compose files
+2. Parses services
+3. Identifies obs services
+4. Detects project name
+5. Builds port map
+6. Generates toml content
+Uses defaults for all values (first compose file, detected name as prefix, `/api/v1/health` as health endpoint).
+
+The existing `init_command()` remains the interactive path — it calls `detect_project()` then overrides values via `typer.prompt()` before writing.
+
+**Tests:** `tests/unit/test_cli_init.py`
+- [ ] `detect_project()` returns correct InitPlan for compose with app + Jaeger
+- [ ] `detect_project()` handles compose with no obs services
+- [ ] `detect_project()` handles no compose file (compose_path doesn't exist)
+- [ ] `detect_project()` handles empty compose (no services key)
+- [ ] Existing tests still pass (interactive flow unchanged)
+
+**Acceptance Criteria:**
+- [ ] `detect_project()` is a pure function (no prompts, no file writes)
+- [ ] `init_command()` interactive flow unchanged
+- [ ] All existing tests pass
+- [ ] Quality gates pass: `uv run ruff check src/ tests/ && uv run mypy src/`
+
+---
+
+## Task 1.2: Add --dry-run, --auto, and --health-endpoint flags
+
+**File(s):** `src/devops_ai/cli/init_cmd.py`, `src/devops_ai/cli/main.py`
+**Type:** CODING
+**Estimated time:** 1-2 hours
+
+**Description:**
+Add three flags to `kinfra init`:
+- `--dry-run`: Run detection, print plan to stdout, write nothing
+- `--auto`: Accept all detected defaults, skip all prompts
+- `--health-endpoint TEXT`: Override the default health endpoint (useful with --auto)
+
+**Implementation Notes:**
+
+Update `init_command()` signature:
+```python
+def init_command(
+    project_root: Path | None = None,
+    dry_run: bool = False,
+    auto: bool = False,
+    health_endpoint: str | None = None,
+) -> int:
+```
+
+Logic flow:
+1. Call `detect_project()` to get the InitPlan
+2. If `health_endpoint` is provided, override the plan's health endpoint
+3. If not `auto`: prompt for overrides (current behavior)
+4. If `auto` and existing config: auto-confirm update
+5. If `dry_run`: print formatted plan to stdout, return 0
+6. Otherwise: write infra.toml and rewrite compose (current behavior)
+
+Wire in `main.py`:
+```python
+@app.command()
+def init(
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without writing"),
+    auto: bool = typer.Option(False, "--auto", help="Accept defaults, no prompts"),
+    health_endpoint: str | None = typer.Option(None, "--health-endpoint", help="Override health check endpoint"),
+) -> None:
+    code = init_command(dry_run=dry_run, auto=auto, health_endpoint=health_endpoint)
+    raise typer.Exit(code)
+```
+
+Dry-run output format (plain text, not YAML — easy to read in terminal and capture by skill):
+```
+Project: wellness-agent
+Prefix: wellness-agent
+Compose: docker-compose.yml
+
+Services detected:
+  wellness-agent: ports [8080]
+  jaeger: ports [14686, 14317] (observability — will be commented out)
+
+Planned infra.toml:
+  [project]
+  name = "wellness-agent"
+  prefix = "wellness-agent"
+  ...
+
+Compose changes:
+  - Parameterize port 8080 → ${WELLNESS_AGENT_WELLNESS_AGENT_PORT:-8080}
+  - Comment out service: jaeger
+  - Remove depends_on: jaeger
+  - Add kinfra header comment
+  - Backup: docker-compose.yml.bak
+
+No files written (dry run).
+```
+
+**Tests:** `tests/unit/test_cli_init.py`
+- [ ] `--dry-run --auto`: detection runs, output printed, no files created (no infra.toml, no compose changes, no .bak)
+- [ ] `--auto`: uses detected defaults, creates infra.toml and rewrites compose without prompts
+- [ ] `--auto` with existing config: auto-confirms update
+- [ ] `--auto --health-endpoint /health`: uses provided endpoint instead of default
+- [ ] `--dry-run` alone (without --auto): still prompts for values, then previews (no writes)
+- [ ] Existing interactive tests still pass
+
+**Acceptance Criteria:**
+- [ ] `kinfra init --dry-run --auto` produces formatted output and writes nothing
+- [ ] `kinfra init --auto` completes without any prompts
+- [ ] `kinfra init --health-endpoint /custom/health --auto` uses the provided endpoint
+- [ ] Interactive mode (no flags) unchanged
+- [ ] All tests pass
+- [ ] Quality gates pass
+
+---
+
+## Task 1.3: E2E verification
+
+**Type:** VALIDATION
+**Estimated time:** 15 min
+
+**Description:**
+Validate M1 is complete by running `kinfra init --dry-run --auto` against a real project directory.
+
+**Test Steps:**
+
+```bash
+# 1. Create a test project directory
+mkdir -p /tmp/kinfra-test && cd /tmp/kinfra-test
+git init
+cat > docker-compose.yml << 'EOF'
+services:
+  myapp:
+    build: .
+    ports:
+      - "8080:8080"
+  jaeger:
+    image: jaegertracing/jaeger:latest
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+EOF
+cat > pyproject.toml << 'EOF'
+[project]
+name = "test-project"
+EOF
+
+# 2. Dry run — should print plan, write nothing
+kinfra init --dry-run --auto
+# Verify: output shows test-project, ports, obs services
+# Verify: no .devops-ai/infra.toml created
+ls .devops-ai/infra.toml 2>/dev/null && echo "FAIL: files written" || echo "OK: no files"
+
+# 3. Auto run — should create files without prompts
+kinfra init --auto
+# Verify: .devops-ai/infra.toml exists
+cat .devops-ai/infra.toml
+# Verify: compose parameterized
+grep '${' docker-compose.yml
+# Verify: jaeger commented out
+grep '# jaeger:' docker-compose.yml
+# Verify: backup exists
+ls docker-compose.yml.bak
+
+# 4. Re-run auto — should update without prompts
+kinfra init --auto --health-endpoint /custom/health
+cat .devops-ai/infra.toml | grep custom
+
+# 5. Cleanup
+rm -rf /tmp/kinfra-test
+```
+
+**Success Criteria:**
+- [ ] `--dry-run --auto` prints plan, creates no files
+- [ ] `--auto` creates infra.toml and rewrites compose with no interaction
+- [ ] `--auto` re-run updates existing config
+- [ ] `--health-endpoint` override works
+- [ ] All unit tests pass: `uv run pytest tests/unit`
+- [ ] Quality gates pass: `uv run ruff check src/ tests/ && uv run mypy src/`
+
+---
+
+## Milestone 1 Completion Checklist
+
+- [ ] All tasks complete and committed
+- [ ] Unit tests pass: `uv run pytest tests/unit`
+- [ ] E2E verification passes (above)
+- [ ] Quality gates pass: `uv run ruff check src/ tests/ && uv run mypy src/`
+- [ ] No regressions in existing kinfra commands

--- a/docs/designs/kinfra-onboard/implementation/M2_skill.md
+++ b/docs/designs/kinfra-onboard/implementation/M2_skill.md
@@ -1,0 +1,182 @@
+---
+design: ../DESIGN.md
+architecture: ../ARCHITECTURE.md
+---
+
+# Milestone 2: kinfra-onboard skill
+
+**Goal:** A developer runs `/kinfra-onboard` in any project and gets an intelligent, phased onboarding experience with safety checks, OTEL rewiring, and a clean git commit.
+
+---
+
+## Task 2.1: Create kinfra-onboard SKILL.md
+
+**File(s):** `skills/kinfra-onboard/SKILL.md`
+**Type:** CODING
+**Estimated time:** 2-3 hours
+
+**Description:**
+Write the skill document that instructs Claude Code how to run the phased onboarding workflow. This is the intelligence layer that reads a project, assesses safety, calls `kinfra init`, adapts app-level config, and verifies results.
+
+**Implementation Notes:**
+
+The skill follows the same YAML frontmatter pattern as other skills:
+```yaml
+---
+name: kinfra-onboard
+description: Onboard a project to the kinfra sandbox and shared observability ecosystem.
+metadata:
+  version: "0.1.0"
+---
+```
+
+**Structure the skill in these sections:**
+
+1. **Invocation** — `/kinfra-onboard [--check]`
+
+2. **Prerequisites** — kinfra CLI must be installed (`which kinfra`), project must be a git repo
+
+3. **Phase 1: Analyze** — Read-only assessment:
+   - Read `.devops-ai/project.md` (project name, existing config)
+   - Read `.devops-ai/infra.toml` (already onboarded?)
+   - Find and read `docker-compose*.yml` / `compose*.yml`
+   - Scan for OTEL config: search for `otel`, `4317`, `jaeger` in config files (YAML, .env, etc.) — NOT in Python source
+   - Run `git status --porcelain` to check for dirty state
+   - **Report findings** in structured format (project name, services, obs services, OTEL config location, git state, onboarding status)
+   - **Blockers:** If already onboarded, report and offer re-run. If dirty git, warn and pause. If no compose, offer worktree-only setup.
+   - **--check mode:** Stop here, report only.
+
+4. **Phase 2: Propose** — Preview changes:
+   - Run `kinfra init --dry-run --auto` (add `--health-endpoint <detected>` if healthcheck found in compose)
+   - Identify OTEL config changes needed: old endpoint → `http://localhost:44317`
+   - Identify project.md changes: add/update Infrastructure section
+   - Identify docs/skills referencing old local obs endpoints
+   - **Present full plan** to user: kinfra dry-run output + skill's own planned changes
+   - **Wait for user approval** before proceeding
+
+5. **Phase 3: Execute** — Make changes:
+   - Run `kinfra init --auto` (add `--health-endpoint` if detected)
+   - Edit OTEL config files: change endpoint to `http://localhost:44317`
+   - Edit `.devops-ai/project.md`: add Infrastructure section with:
+     ```
+     ## Infrastructure
+     - **Start:** kinfra impl <feature>/<milestone>
+     - **Stop:** kinfra done <name>
+     - **Observability:** kinfra observability up
+     - **Status:** kinfra status
+     ```
+   - Edit docs/skills referencing old Jaeger ports (e.g. `14686` → `46686`, `14317` → `44317`)
+   - **Track all changed files** for the commit
+
+6. **Phase 4: Verify & Commit** — Validate and commit:
+   - Verify `.devops-ai/infra.toml` exists and is valid TOML
+   - Verify compose file is valid YAML (read and parse)
+   - Verify no remaining references to old obs endpoints in config files
+   - `git add <tracked files>` (explicit list, never `-A`)
+   - `git commit -m "chore: onboard to kinfra sandbox and shared observability"`
+   - Report summary of all changes
+
+7. **Error Handling** section:
+   - kinfra not found → "Run install.sh in devops-ai"
+   - kinfra init fails → Show error, discuss with user
+   - Verification fails → Full rollback (restore .bak, delete infra.toml, git checkout edited files)
+   - OTEL config not found → Report to user, skip OTEL rewiring (app may not have observability)
+   - OTEL config in Python source only → Surface to user, recommend adding config-based override
+
+8. **Shared Observability Reference** section:
+   - Shared stack ports: Jaeger UI `46686`, Grafana `43000`, Prometheus `49090`, OTLP gRPC `44317`
+   - OTEL endpoint for app config: `http://localhost:44317`
+   - In sandbox: env var `OTEL_EXPORTER_OTLP_ENDPOINT=http://devops-ai-jaeger:4317` overrides config
+   - Start stack: `kinfra observability up`
+
+**Tests:**
+- Manual validation (Task 2.2)
+
+**Acceptance Criteria:**
+- [ ] SKILL.md follows frontmatter + sections pattern from other skills
+- [ ] All 4 phases documented with clear instructions
+- [ ] --check mode documented
+- [ ] Error handling section covers all cases from SCENARIOS.md
+- [ ] Shared observability reference section included
+- [ ] Skill is discoverable after `install.sh` run (symlinked to `~/.claude/skills/`)
+
+---
+
+## Task 2.2: E2E validation on khealth
+
+**Type:** VALIDATION
+**Estimated time:** 30 min
+
+**Description:**
+Run `/kinfra-onboard` on the khealth project (`../khealth`) to validate the full 4-phase flow works end-to-end.
+
+**Prerequisites:**
+- M1 complete (kinfra init --dry-run --auto working)
+- khealth has clean git state
+- Skill installed (run `install.sh` or symlink manually)
+
+**Test Steps:**
+
+1. **Prep:** Ensure khealth is on a clean branch
+```bash
+cd /Users/karl/Documents/dev/khealth
+git status  # should be clean
+```
+
+2. **--check mode first:** Run `/kinfra-onboard --check` in khealth
+   - Verify: Reports project name (wellness-agent), compose services, Jaeger obs service, OTEL config at config.yaml, git clean, not onboarded
+   - Verify: No files changed
+
+3. **Full onboarding:** Run `/kinfra-onboard` in khealth
+   - Phase 1: Verify analysis report matches --check output
+   - Phase 2: Verify proposal shows kinfra dry-run output + OTEL rewiring plan. Approve.
+   - Phase 3: Verify execution:
+     - `.devops-ai/infra.toml` created
+     - `docker-compose.yml` parameterized (port 8080 has `${...:-8080}`)
+     - `docker-compose.yml` has Jaeger commented out
+     - `config.yaml` OTEL endpoint → `http://localhost:44317`
+     - `.devops-ai/project.md` has Infrastructure section
+   - Phase 4: Verify commit created with all changed files
+
+4. **Post-onboarding checks:**
+```bash
+# infra.toml is valid
+cat .devops-ai/infra.toml
+
+# compose still parses
+python3 -c "from ruamel.yaml import YAML; YAML().load(open('docker-compose.yml'))"
+
+# OTEL points to shared stack
+grep 44317 config.yaml
+
+# project.md has Infrastructure
+grep -A5 "## Infrastructure" .devops-ai/project.md
+
+# git log shows commit
+git log --oneline -1
+```
+
+5. **Cleanup:** Revert the onboarding commit if this is just validation
+```bash
+git revert HEAD --no-edit  # or reset if preferred
+```
+
+**Success Criteria:**
+- [ ] --check mode reports correctly without changing files
+- [ ] Full onboarding completes all 4 phases
+- [ ] infra.toml is valid and contains correct project name and ports
+- [ ] Compose is parameterized with Jaeger commented out
+- [ ] OTEL endpoint updated to shared stack
+- [ ] project.md has Infrastructure section
+- [ ] Single git commit contains all changes
+- [ ] No regressions in kinfra unit tests: `cd /Users/karl/Documents/dev/devops-ai && uv run pytest tests/unit`
+
+---
+
+## Milestone 2 Completion Checklist
+
+- [ ] SKILL.md created and follows conventions
+- [ ] install.sh picks up new skill automatically
+- [ ] E2E validation on khealth passes
+- [ ] kinfra unit tests still pass: `uv run pytest tests/unit`
+- [ ] Quality gates pass: `uv run ruff check src/ tests/ && uv run mypy src/`

--- a/docs/designs/kinfra-onboard/implementation/OVERVIEW.md
+++ b/docs/designs/kinfra-onboard/implementation/OVERVIEW.md
@@ -1,0 +1,22 @@
+# kinfra-onboard Implementation Plan
+
+## Milestone Summary
+
+| # | Name | Tasks | E2E Test | Status |
+|---|------|-------|----------|--------|
+| M1 | kinfra init --dry-run and --auto | 3 | `kinfra init --dry-run --auto` on test project, no files written | - |
+| M2 | kinfra-onboard skill | 2 | `/kinfra-onboard` on khealth, full 4-phase flow | - |
+
+## Dependency Graph
+
+```
+M1 → M2
+```
+
+M1 delivers the CLI flags that M2's skill depends on.
+
+## Reference Documents
+
+- Design: `../DESIGN.md`
+- Architecture: `../ARCHITECTURE.md`
+- Validation: `../SCENARIOS.md`

--- a/src/devops_ai/cli/init_cmd.py
+++ b/src/devops_ai/cli/init_cmd.py
@@ -346,7 +346,7 @@ def _format_dry_run_output(plan: InitPlan) -> str:
         lines.append(f"  - Comment out service: {obs_name}")
     if plan.obs_services:
         lines.append("  - Remove depends_on references to obs services")
-    if plan.services:
+    if plan.ports or plan.obs_services:
         lines.append("  - Add kinfra header comment")
         lines.append(
             f"  - Backup: {plan.compose_file}.bak"

--- a/src/devops_ai/cli/init_cmd.py
+++ b/src/devops_ai/cli/init_cmd.py
@@ -6,6 +6,7 @@ import json
 import re
 import subprocess
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +22,89 @@ OBSERVABILITY_PATTERNS = [
     re.compile(r"^prom/prometheus"),
     re.compile(r"^grafana/grafana"),
 ]
+
+
+@dataclass
+class InitPlan:
+    """Structured result of project detection — no prompts, no file writes."""
+
+    project_root: Path
+    project_name: str
+    prefix: str
+    compose_file: str
+    compose_path: Path
+    services: dict[str, dict[str, Any]]
+    obs_services: list[str]
+    app_services: dict[str, dict[str, Any]]
+    ports: dict[str, int]
+    health_endpoint: str | None
+    health_port_var: str | None
+    toml_content: str = ""
+
+
+def detect_project(project_root: Path) -> InitPlan:
+    """Run the full detection pipeline and return a structured plan.
+
+    Pure function — no prompts, no file writes.
+    """
+    # Find compose files
+    compose_files = find_compose_files(project_root)
+    compose_file = compose_files[0].name if compose_files else "docker-compose.yml"
+    compose_path = project_root / compose_file
+
+    # Parse services
+    services: dict[str, dict[str, Any]] = {}
+    if compose_path.exists():
+        services = detect_services_from_compose(compose_path.read_text())
+
+    # Identify obs vs app services
+    obs_services = identify_observability_services(services)
+    app_services = {k: v for k, v in services.items() if k not in obs_services}
+
+    # Detect project name
+    project_name = detect_project_name(project_root)
+    prefix = project_name
+
+    # Default health endpoint
+    health_endpoint: str | None = "/api/v1/health"
+    health_port_var: str | None = None
+
+    # Build port map from app services
+    ports: dict[str, int] = {}
+    for svc_name, svc in app_services.items():
+        for port_info in svc["ports"]:
+            var_name = (
+                f"{prefix.upper().replace('-', '_')}"
+                f"_{svc_name.upper().replace('-', '_')}_PORT"
+            )
+            ports[var_name] = port_info["host"]
+            if health_port_var is None and health_endpoint:
+                health_port_var = var_name
+
+    # Generate toml content
+    toml_content = generate_infra_toml(
+        project_name=project_name,
+        prefix=prefix,
+        compose_file=compose_file,
+        ports=ports,
+        health_endpoint=health_endpoint,
+        health_port_var=health_port_var,
+    )
+
+    return InitPlan(
+        project_root=project_root,
+        project_name=project_name,
+        prefix=prefix,
+        compose_file=compose_file,
+        compose_path=compose_path,
+        services=services,
+        obs_services=obs_services,
+        app_services=app_services,
+        ports=ports,
+        health_endpoint=health_endpoint,
+        health_port_var=health_port_var,
+        toml_content=toml_content,
+    )
 
 
 def detect_services_from_compose(
@@ -250,7 +334,10 @@ def init_command(project_root: Path | None = None) -> int:
             "Init can proceed, but sandbox features need Docker."
         )
 
-    # Find compose files
+    # Run detection pipeline
+    plan = detect_project(project_root)
+
+    # Interactive overrides for compose file selection
     compose_files = find_compose_files(project_root)
     if not compose_files:
         typer.echo("No docker-compose.yml or compose.yml found.")
@@ -267,51 +354,49 @@ def init_command(project_root: Path | None = None) -> int:
             "Which compose file?", default=compose_files[0].name
         )
 
-    # Parse services
-    compose_path = project_root / compose_file
-    services: dict[str, dict[str, Any]] = {}
-    if compose_path.exists():
-        services = detect_services_from_compose(
-            compose_path.read_text()
-        )
-
-    # Identify observability services
-    obs_services = identify_observability_services(services)
-    app_services = {
-        k: v for k, v in services.items() if k not in obs_services
-    }
-
-    if services:
-        typer.echo(f"\nDetected {len(services)} services:")
-        for name, svc in services.items():
+    # Display detected services
+    if plan.services:
+        typer.echo(f"\nDetected {len(plan.services)} services:")
+        for name, svc in plan.services.items():
             ports_str = ", ".join(
                 str(p["host"]) for p in svc["ports"]
             )
-            label = " (observability)" if name in obs_services else ""
+            label = (
+                " (observability)" if name in plan.obs_services else ""
+            )
             typer.echo(f"  {name}: ports [{ports_str}]{label}")
 
-    if obs_services:
+    if plan.obs_services:
         typer.echo(
-            f"\nObservability services ({', '.join(obs_services)}) "
+            f"\nObservability services ({', '.join(plan.obs_services)}) "
             "will be provided by kinfra's shared stack."
         )
 
-    # Detect project name
-    detected_name = detect_project_name(project_root)
+    # Interactive overrides for project name, prefix, health
     project_name = typer.prompt(
-        "Project name", default=detected_name
+        "Project name", default=plan.project_name
     )
     prefix = typer.prompt("Worktree prefix", default=project_name)
 
-    # Health endpoint
-    health_endpoint = typer.prompt(
+    health_endpoint: str | None = typer.prompt(
         "Health check endpoint (empty to skip)",
         default="/api/v1/health",
     )
     if not health_endpoint:
         health_endpoint = None
 
-    # Build port map for app services
+    # Rebuild port map and toml with possibly-overridden values
+    compose_path = project_root / compose_file
+    services: dict[str, dict[str, Any]] = {}
+    if compose_path.exists():
+        services = detect_services_from_compose(
+            compose_path.read_text()
+        )
+    obs_services = identify_observability_services(services)
+    app_services = {
+        k: v for k, v in services.items() if k not in obs_services
+    }
+
     ports: dict[str, int] = {}
     health_port_var: str | None = None
     for svc_name, svc in app_services.items():
@@ -324,7 +409,6 @@ def init_command(project_root: Path | None = None) -> int:
             if health_port_var is None and health_endpoint:
                 health_port_var = var_name
 
-    # Generate and write config
     toml_content = generate_infra_toml(
         project_name=project_name,
         prefix=prefix,

--- a/src/devops_ai/cli/main.py
+++ b/src/devops_ai/cli/main.py
@@ -24,9 +24,25 @@ app.add_typer(observability_app, name="observability")
 
 
 @app.command()
-def init() -> None:
+def init(
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview changes without writing"
+    ),
+    auto: bool = typer.Option(
+        False, "--auto", help="Accept defaults, no prompts"
+    ),
+    health_endpoint: str | None = typer.Option(
+        None,
+        "--health-endpoint",
+        help="Override health check endpoint",
+    ),
+) -> None:
     """Initialize kinfra for the current project."""
-    code = init_command()
+    code = init_command(
+        dry_run=dry_run,
+        auto=auto,
+        health_endpoint=health_endpoint,
+    )
     raise typer.Exit(code)
 
 


### PR DESCRIPTION
## Summary

- Refactored `init_command()` to extract detection pipeline into pure `detect_project()` function returning an `InitPlan` dataclass
- Added `--dry-run` flag: previews all changes (infra.toml content, compose modifications) without writing files
- Added `--auto` flag: accepts all detected defaults, skips interactive prompts
- Added `--health-endpoint` flag: overrides the default health check endpoint
- Interactive mode (no flags) unchanged

## Test plan

- [x] 6 new unit tests covering all flag combinations (dry-run+auto, dry-run alone, auto, auto+existing config, auto+health-endpoint, interactive unchanged)
- [x] 5 existing `detect_project()` tests from refactor
- [x] All 183 unit tests pass, ruff + mypy clean
- [x] Manual E2E validation: created temp project, verified `--dry-run --auto` writes nothing, `--auto` creates config + rewrites compose, re-run updates existing config, `--health-endpoint` override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)