### PR TITLE
feat: provisioning discovery in kinfra init

### DIFF
--- a/src/devops_ai/cli/main.py
+++ b/src/devops_ai/cli/main.py
@@ -43,12 +43,16 @@ def init(
         "--health-endpoint",
         help="Override health check endpoint",
     ),
+    check: bool = typer.Option(
+        False, "--check", help="Report provisioning gaps"
+    ),
 ) -> None:
     """Initialize kinfra for the current project."""
     code = init_command(
         dry_run=dry_run,
         auto=auto,
         health_endpoint=health_endpoint,
+        check=check,
     )
     raise typer.Exit(code)
 

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -1,9 +1,12 @@
 """Tests for kinfra init — project inspection + config generation."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 from devops_ai.cli.init_cmd import (
     InitPlan,
+    detect_env_vars,
+    detect_gitignored_mounts,
     detect_project,
     detect_project_name,
     detect_services_from_compose,
@@ -543,3 +546,190 @@ class TestInitAuto:
         assert code == 0
         toml = (tmp_path / ".devops-ai" / "infra.toml").read_text()
         assert 'name = "interproj"' in toml
+
+
+# --- Env var detection ---
+
+COMPOSE_WITH_ENV_VARS = """\
+services:
+  myapp:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - APP_SECRET=${APP_SECRET}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - CONFIG_PATH=/app/config.yaml
+  worker:
+    image: python:3.12
+    environment:
+      APP_SECRET: ${APP_SECRET}
+      WORKER_TOKEN: ${WORKER_TOKEN}
+"""
+
+COMPOSE_WITH_VOLUMES = """\
+services:
+  myapp:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./config.yaml:/app/config.yaml:ro
+      - ./data:/app/data
+      - app-data:/app/persistent
+      - ./.env:/app/.env
+
+volumes:
+  app-data:
+"""
+
+
+class TestDetectEnvVars:
+    def test_finds_simple_var_references(self) -> None:
+        candidates = detect_env_vars(COMPOSE_WITH_ENV_VARS, set())
+        names = {c.name for c in candidates}
+        assert "APP_SECRET" in names
+        assert "WORKER_TOKEN" in names
+
+    def test_finds_var_with_default(self) -> None:
+        candidates = detect_env_vars(COMPOSE_WITH_ENV_VARS, set())
+        log_level = next(c for c in candidates if c.name == "LOG_LEVEL")
+        assert log_level.default == "info"
+
+    def test_excludes_known_vars(self) -> None:
+        known = {"APP_SECRET", "COMPOSE_PROJECT_NAME"}
+        candidates = detect_env_vars(COMPOSE_WITH_ENV_VARS, known)
+        names = {c.name for c in candidates}
+        assert "APP_SECRET" not in names
+        assert "LOG_LEVEL" in names
+
+    def test_excludes_otel_and_compose_vars(self) -> None:
+        known = {
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_RESOURCE_ATTRIBUTES",
+            "COMPOSE_PROJECT_NAME",
+        }
+        compose = (
+            "services:\n  app:\n    environment:\n"
+            "      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}\n"
+            "      - MY_VAR=${MY_VAR}\n"
+        )
+        candidates = detect_env_vars(compose, known)
+        names = {c.name for c in candidates}
+        assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in names
+        assert "MY_VAR" in names
+
+    def test_identifies_services(self) -> None:
+        candidates = detect_env_vars(COMPOSE_WITH_ENV_VARS, set())
+        app_secret = next(c for c in candidates if c.name == "APP_SECRET")
+        assert "myapp" in app_secret.services
+        assert "worker" in app_secret.services
+
+    def test_handles_no_env_var_references(self) -> None:
+        compose = "services:\n  app:\n    build: .\n"
+        candidates = detect_env_vars(compose, set())
+        assert candidates == []
+
+    def test_deduplicates_vars(self) -> None:
+        """Same var in multiple services → one candidate with both services."""
+        candidates = detect_env_vars(COMPOSE_WITH_ENV_VARS, set())
+        app_secret_entries = [c for c in candidates if c.name == "APP_SECRET"]
+        assert len(app_secret_entries) == 1
+
+
+class TestDetectGitignoredMounts:
+    def test_identifies_gitignored_bind_mounts(
+        self, tmp_path: Path
+    ) -> None:
+        # Mock git check-ignore: config.yaml is ignored, data/ is not
+        def mock_check_ignore(
+            cmd, capture_output, text, timeout, cwd,
+        ):
+            from unittest.mock import MagicMock
+
+            path = cmd[-1]
+            result = MagicMock()
+            result.returncode = 0 if path == "config.yaml" else 1
+            return result
+
+        with patch("devops_ai.cli.init_cmd.subprocess.run", mock_check_ignore):
+            candidates = detect_gitignored_mounts(
+                COMPOSE_WITH_VOLUMES, tmp_path
+            )
+
+        host_paths = {c.host_path for c in candidates}
+        assert "config.yaml" in host_paths
+
+    def test_skips_named_volumes(self, tmp_path: Path) -> None:
+        # All bind mounts non-ignored
+        def mock_check_ignore(cmd, capture_output, text, timeout, cwd):
+            from unittest.mock import MagicMock
+
+            result = MagicMock()
+            result.returncode = 1  # not ignored
+            return result
+
+        with patch("devops_ai.cli.init_cmd.subprocess.run", mock_check_ignore):
+            candidates = detect_gitignored_mounts(
+                COMPOSE_WITH_VOLUMES, tmp_path
+            )
+
+        # Named volume 'app-data' should never appear
+        host_paths = {c.host_path for c in candidates}
+        assert "app-data" not in host_paths
+        assert "app-persistent" not in host_paths
+
+    def test_checks_source_existence_and_example(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "config.yaml").write_text("setting: value")
+        (tmp_path / ".env.example").write_text("KEY=val")
+
+        def mock_check_ignore(cmd, capture_output, text, timeout, cwd):
+            from unittest.mock import MagicMock
+
+            path = cmd[-1]
+            result = MagicMock()
+            # config.yaml and .env are ignored
+            result.returncode = 0 if path in ("config.yaml", ".env") else 1
+            return result
+
+        with patch("devops_ai.cli.init_cmd.subprocess.run", mock_check_ignore):
+            candidates = detect_gitignored_mounts(
+                COMPOSE_WITH_VOLUMES, tmp_path
+            )
+
+        config = next(c for c in candidates if c.host_path == "config.yaml")
+        assert config.source_exists is True
+        assert config.example_exists is False
+
+        env_c = next(c for c in candidates if c.host_path == ".env")
+        assert env_c.source_exists is False
+        assert env_c.example_exists is True
+        assert env_c.example_path == ".env.example"
+
+    def test_handles_compose_with_no_bind_mounts(
+        self, tmp_path: Path
+    ) -> None:
+        compose = "services:\n  app:\n    build: .\n"
+        candidates = detect_gitignored_mounts(compose, tmp_path)
+        assert candidates == []
+
+
+class TestDetectProjectPopulatesNewFields:
+    def test_env_var_candidates_populated(self, tmp_path: Path) -> None:
+        compose = (
+            "services:\n  myapp:\n    build: .\n"
+            "    ports:\n      - \"8080:8080\"\n"
+            "    environment:\n      - MY_SECRET=${MY_SECRET}\n"
+        )
+        (tmp_path / "docker-compose.yml").write_text(compose)
+
+        plan = detect_project(tmp_path)
+
+        assert hasattr(plan, "env_var_candidates")
+        names = {c.name for c in plan.env_var_candidates}
+        assert "MY_SECRET" in names
+        # Port vars should be excluded
+        for c in plan.env_var_candidates:
+            assert c.name not in plan.ports


### PR DESCRIPTION
## Summary
- Add `detect_env_vars()` and `detect_gitignored_mounts()` to find undeclared env vars and gitignored bind mounts in compose files
- Extend `generate_infra_toml()` with `[sandbox.env]`, `[sandbox.secrets]`, and `[sandbox.files]` sections
- Wire `--check` flag into CLI to report provisioning gaps on already-onboarded projects
- Auto mode generates complete infra.toml with provisioning sections
- Check mode loads existing config to exclude already-declared items and parameterized port vars

## E2E Tests Performed

| Test | Steps | Result |
|------|-------|--------|
| Dry-run detection | `kinfra init --dry-run --auto` on test project | PASSED |
| Auto init with provisioning | `kinfra init --auto` on test project | PASSED |
| Check gap detection | Added new env var, `kinfra init --check` | PASSED |
| Check no gaps | `kinfra init --check` with all vars declared | PASSED |
| khealth check | `kinfra init --check` on khealth project | PASSED |

## Test plan
- [x] 252 unit tests pass
- [x] ruff + mypy clean
- [x] E2E validation against test project and khealth
- [x] No regressions in existing kinfra commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)