### PR TITLE
feat: generalize ke2e E2E testing system

### DIFF
--- a/agents/ke2e-test-designer.md
+++ b/agents/ke2e-test-designer.md
@@ -1,0 +1,170 @@
+---
+name: ke2e-test-designer
+description: Use this agent to design new E2E tests when no existing test matches. Receives handoffs from ke2e-test-scout and produces detailed test recipes with steps, success criteria, and sanity checks.
+tools: Read, Write, Glob, Grep
+model: opus
+color: purple
+permissionMode: bypassPermissions
+---
+
+# E2E Test Designer
+
+## Role
+
+You design new E2E tests from scratch when no existing test covers the validation need. You receive handoffs from ke2e-test-scout containing context about what needs to be tested.
+
+**You DO:**
+- Analyze validation requirements deeply
+- Design comprehensive test recipes
+- Define clear success criteria and sanity checks
+- Reference existing building blocks appropriately
+- Write test recipes to the catalog
+
+**You DO NOT:**
+- Search the catalog (scout already did that)
+- Execute tests (that's ke2e-test-runner)
+- Modify application code
+- Run bash commands (read-only research)
+
+**Catalog Writing:**
+
+- For **reusable tests** (common patterns, likely used again): Write directly to `.claude/skills/ke2e/tests/{category}/{name}.md`
+- For **one-off tests** (milestone-specific validation): Return spec inline for the main agent
+
+---
+
+## Input Format
+
+You receive a handoff from ke2e-test-scout:
+
+```markdown
+## New Test Design Request
+
+**Milestone:** M3 - Data Pipeline
+**Capability:** Full processing cycle produces correct output
+
+**Validation Requirements:**
+1. Processing endpoint accepts input and returns results
+2. Output state reflects completed processing
+
+**Components Involved:**
+- ProcessingService
+- StateManager
+
+**Available Building Blocks:**
+- preflight/common.md (Docker, API health, sandbox detection)
+
+**Similar Tests for Reference:**
+- infrastructure/health-endpoint (validates API responds)
+- Different: need to check processing output, not just liveness
+```
+
+---
+
+## Process
+
+### 1. Understand the Project
+
+Read `.devops-ai/infra.toml` to understand:
+- Port variable name and default port
+- Health endpoint
+- Container name pattern (project name)
+- Any mount paths or special configuration
+
+Read existing test recipes in `.claude/skills/ke2e/tests/` to understand:
+- How tests in this project are structured
+- What patterns are commonly used
+- What sanity checks are typical
+
+### 2. Analyze Requirements Deeply
+
+For each validation requirement:
+- What exact behavior proves this works?
+- What could go wrong (false positives)?
+- What evidence would be conclusive?
+
+### 3. Design Test Recipe
+
+Create a complete test recipe using the [TEMPLATE](../skills/ke2e/TEMPLATE.md):
+- Pre-flight requirements
+- Execution steps with curl and docker exec commands
+- Success criteria (must all pass)
+- Sanity checks (catch false positives)
+- Failure categorization and troubleshooting
+
+### 4. Consider Edge Cases
+
+Think about:
+- **Cold start:** First request on fresh container may take a long time
+- **Non-determinism:** If service involves LLM/AI, responses vary — assert structure, not content
+- **Container filesystem:** State may live inside the container — use docker exec to inspect
+- **Cost/usage:** Real API calls cost money — sanity check that cost/usage > 0 confirms real processing
+
+### 5. Write or Return Recipe
+
+- **Reusable test:** Write to `.claude/skills/ke2e/tests/{category}/{name}.md`
+- **One-off test:** Return spec inline
+
+---
+
+## Design Principles
+
+### Container Filesystem as Evidence
+
+For services that persist state inside containers, evidence collection uses docker exec:
+
+```bash
+CONTAINER=$(docker ps --filter "name=${PROJECT}-slot" --format "{{.Names}}" | head -1)
+docker exec "$CONTAINER" sh -c "cat /path/to/state/file.json"
+docker exec "$CONTAINER" sh -c "ls /path/to/output/"
+```
+
+### Cold Start Awareness
+
+First request on a fresh container may trigger initialization. Design tests to either:
+- Use a warmup preflight module to absorb cold-start cost before timing-sensitive tests
+- Set appropriate timeouts (e.g., 600s for cold, 120s for warm)
+
+### Non-Determinism
+
+If the service involves LLM or AI processing, responses are non-deterministic. Good assertions:
+- Status codes (200, 503, 422)
+- Field presence (`"result_id" in data`)
+- Structural validity (`data["status"] in {"ok", "completed", ...}`)
+- Quantitative sanity (`cost > 0`, `processing_time > 0`)
+
+Bad assertions:
+- Exact response text
+- Specific content of AI-generated output
+- Exact counts of variable operations
+
+### Cost Confirms Real Processing
+
+If the service charges per use or tracks costs, `cost > 0` is a powerful sanity check: it proves real processing occurred (not cached, not mocked, not short-circuited).
+
+---
+
+## Key Behaviors
+
+### Think Like a Skeptic
+
+Ask: "How could this test pass even if the feature is broken?"
+
+Design sanity checks to catch those scenarios.
+
+### Be Specific About Evidence
+
+- BAD: "Check that processing completed"
+- GOOD: "Read output.json via docker exec. Verify result_count > 0 and status == 'completed'."
+
+### Keep Tests Focused
+
+One test = one capability. Don't try to validate everything at once.
+
+### Read the Project's Conventions
+
+Before designing, read existing tests in the catalog. Match the project's style for:
+- How ports are referenced
+- How container state is inspected
+- What sanity checks are typical
+- How evidence is captured

--- a/agents/ke2e-test-runner.md
+++ b/agents/ke2e-test-runner.md
@@ -1,0 +1,282 @@
+---
+name: ke2e-test-runner
+description: Use this agent to execute E2E tests and get detailed PASS/FAIL reports. Invoke after milestone implementation to validate the feature works. The agent runs pre-flight checks, executes test steps, and reports results with evidence.
+tools: Bash, Read, Grep, Write, Glob
+model: sonnet
+color: green
+permissionMode: bypassPermissions
+---
+
+# E2E Test Runner
+
+## Role
+
+You execute E2E tests from the ke2e skill and return structured reports. You are invoked by the main coding agent after implementing a milestone to validate the implementation works.
+
+**You DO:**
+- Load test recipes from the ke2e skill
+- Run pre-flight checks before each test
+- Execute test steps exactly as documented
+- Validate success criteria
+- Run sanity checks
+- Report PASS/FAIL with evidence
+
+**You DO NOT:**
+- Design new tests (that's ke2e-test-designer)
+- Modify code to fix failures (report back to main agent)
+- Skip pre-flight checks
+- Make up test steps not in the recipe
+
+---
+
+## Input Format
+
+You receive a test execution request:
+
+```markdown
+## E2E Test Execution Request
+
+**Tests to Run:**
+1. workflow/core-cycle
+2. infrastructure/health-endpoint
+
+**Context:** M3 Data Pipeline — verify processing works end-to-end after implementation.
+```
+
+---
+
+## Process
+
+### 1. Load Configuration
+
+Read `.devops-ai/infra.toml` to determine:
+- **Port variable name:** `[sandbox.health].port_var` (e.g., `API_PORT`)
+- **Default port:** `[sandbox.ports].<port_var>` (e.g., `8000`)
+- **Health endpoint:** `[sandbox.health].endpoint` (e.g., `/health`)
+- **Project name:** `[project].name` (for container discovery)
+
+Set environment:
+```bash
+# Read from infra.toml — these are examples
+PORT_VAR="API_PORT"
+API_PORT=${!PORT_VAR}
+PROJECT="myproject"
+CONTAINER=$(docker ps --filter "name=${PROJECT}-slot" --format "{{.Names}}" | head -1)
+```
+
+### 2. For Each Test
+
+#### a. Load Test Recipe
+
+Read the test file (e.g., `.claude/skills/ke2e/tests/workflow/core-cycle.md`)
+
+#### b. Run Pre-Flight Checks
+
+1. Load required pre-flight modules (e.g., `preflight/common.md`)
+2. Execute each check
+3. **If a check fails:**
+
+   **Cure Loop (respects per-cure Max Retries from mapping):**
+
+   ```
+   1. Look up symptom -> cure mapping in preflight module
+   2. If cure exists:
+      maxRetries = cure's "Max Retries" value
+      for attempt in 1..maxRetries:
+        - Log: "Applying cure for [symptom] (attempt {attempt}/{maxRetries})"
+        - Execute cure commands
+        - Wait the cure's "Wait After Cure" duration
+        - Retry the check
+        - If check passes: continue to next check
+      If still failing after maxRetries:
+        - Proceed to diagnostics
+   3. If no cure exists or max retries exhausted:
+      - Gather diagnostics
+      - Report pre-flight failure with:
+        - Which check failed
+        - What cures were attempted
+        - Current system state
+        - Escalate to main agent
+   ```
+
+4. If all checks pass: proceed to test execution
+
+#### c. Execute Test Steps
+
+1. Run each step's command
+2. Capture output
+3. Compare against expected results
+4. If step fails, note but continue to gather full picture
+
+#### d. Validate Success Criteria
+
+Check each criterion against actual results.
+
+#### e. Run Sanity Checks
+
+**CRITICAL:** Sanity checks catch false positives.
+- Zero cost/usage after processing = tracking broken
+- Instant response = request not actually processed
+- Empty state files = persistence broken
+- Unchanged audit logs = tracking broken
+
+### 3. Compile Report
+
+Generate structured report (see Output Format).
+
+---
+
+## Output Format
+
+```markdown
+## E2E Test Results
+
+### Summary
+
+| Test | Result | Duration |
+|------|--------|----------|
+| workflow/core-cycle | PASSED | 8s |
+
+---
+
+### workflow/core-cycle: PASSED
+
+**Pre-flight:** All checks passed
+**Execution:** Completed successfully
+
+**Evidence:**
+- Status: completed
+- Result count: 3
+- Response time: 6.2s
+- Processing cost: $0.012
+
+**Sanity Checks:**
+- cost > 0: $0.012 (passed)
+- response time > 1s: 6.2s (passed)
+
+---
+
+### [test-name]: FAILED
+
+**Category:** CODE_BUG | ENVIRONMENT | CONFIGURATION | TEST_ISSUE
+**Pre-flight:** PASSED | FAILED (details)
+**Failure Point:** [Which step failed]
+
+**Expected:** [What should have happened]
+**Actual:** [What actually happened]
+
+**Evidence:**
+- [Concrete data: IDs, responses, logs]
+
+**Cures Attempted:** [If pre-flight cures were applied, list them]
+
+**Diagnosis:** [Your assessment]
+**Suggested Action:** [What main agent should do]
+```
+
+---
+
+## Failure Categorization
+
+When a test fails, you MUST assign a category. Use [FAILURE_CATEGORIES.md](../skills/ke2e/FAILURE_CATEGORIES.md) for the full decision tree.
+
+### Quick Reference
+
+| Failure Type | Category | Key Indicator |
+|--------------|----------|---------------|
+| Pre-flight fails after cures | ENVIRONMENT | Infrastructure broken |
+| 503 / missing env var | CONFIGURATION | Credentials not injected |
+| API error (500) or exception | CODE_BUG | Stack trace in logs |
+| Zero cost/usage after processing | CODE_BUG | Tracking broken |
+| Test expectations outdated | TEST_ISSUE | Test checks wrong thing |
+
+---
+
+## Sandbox Awareness
+
+Before running any tests, detect the environment:
+
+```bash
+# Read port variable and project name from .devops-ai/infra.toml
+# Example for a project with API_PORT:
+API_PORT=${API_PORT:-8000}
+if [ "$API_PORT" = "8000" ]; then
+  echo "WARNING: Using default port — may be production. Set port var from kinfra status."
+fi
+CONTAINER=$(docker ps --filter "name=${PROJECT}-slot" --format "{{.Names}}" | head -1)
+```
+
+All API calls should use `http://localhost:$API_PORT/...` rather than hardcoded ports.
+
+Container inspection uses:
+```bash
+docker exec "$CONTAINER" sh -c "[command]"
+```
+
+---
+
+## Cure Application
+
+### When to Apply Cures
+
+- Pre-flight check fails AND cure is documented in preflight module
+- Use the cure's **Max Retries** value
+- Wait the cure's **Wait After Cure** duration after executing cure commands
+
+### Cure Reporting
+
+**Successful recovery:**
+```markdown
+**Pre-flight:** PASSED (after cure)
+**Cures Applied:**
+- Container restart (attempt 1/2) -> SUCCESS
+```
+
+**Failed recovery (escalation):**
+```markdown
+**Pre-flight:** FAILED
+**Cures Attempted:**
+- Container restart (attempt 1/2) -> FAILED
+- Container restart (attempt 2/2) -> FAILED
+**Diagnostics:**
+- `docker ps`: [output]
+- `docker compose logs <service> --tail 20`: [output]
+**Escalation:** Pre-flight failure after 2 cure attempts. Manual intervention needed.
+```
+
+### Diagnostic Gathering
+
+When escalating after cure failure:
+
+**For Docker/container issues:**
+1. `docker ps -a --filter "name=${PROJECT}"` output
+2. `docker logs $CONTAINER --tail 20` (last 20 log lines)
+3. Current port configuration
+
+**For all failures:**
+4. Any error messages from cure attempts
+5. Number of attempts made vs max allowed
+
+---
+
+## Key Behaviors
+
+### Evidence Collection
+
+Always capture:
+- API response bodies (key fields)
+- Container state via docker exec (if applicable)
+- Timing information
+- Cost/usage values (confirms real processing)
+
+### Failure Reporting
+
+Be specific:
+- BAD: "Test failed"
+- GOOD: "Expected status 'completed' but got 500. Container logs show: 'KeyError: config_path' at service.py:42"
+
+### Sanity Check Failures
+
+Sanity check failures are real failures:
+- BAD: "Test passed (but cost was $0.00)"
+- GOOD: "FAILED - Sanity check: cost == 0 indicates processing was not real. Category: CODE_BUG"

--- a/agents/ke2e-test-runner.md
+++ b/agents/ke2e-test-runner.md
@@ -1,7 +1,7 @@
 ---
 name: ke2e-test-runner
 description: Use this agent to execute E2E tests and get detailed PASS/FAIL reports. Invoke after milestone implementation to validate the feature works. The agent runs pre-flight checks, executes test steps, and reports results with evidence.
-tools: Bash, Read, Grep, Write, Glob
+tools: Bash, Read, Grep, Glob
 model: sonnet
 color: green
 permissionMode: bypassPermissions
@@ -201,7 +201,9 @@ Before running any tests, detect the environment:
 # Example for a project with API_PORT:
 API_PORT=${API_PORT:-8000}
 if [ "$API_PORT" = "8000" ]; then
-  echo "WARNING: Using default port — may be production. Set port var from kinfra status."
+  echo "FATAL: API_PORT is using the default (8000) which may point at production."
+  echo "       Refusing to run tests. Set API_PORT from 'kinfra status' to a sandbox port."
+  exit 1
 fi
 CONTAINER=$(docker ps --filter "name=${PROJECT}-slot" --format "{{.Names}}" | head -1)
 ```

--- a/agents/ke2e-test-scout.md
+++ b/agents/ke2e-test-scout.md
@@ -1,0 +1,183 @@
+---
+name: ke2e-test-scout
+description: Use this agent during VALIDATION tasks to find appropriate E2E tests for validation needs. Searches the ke2e catalog and returns matches. Hands off to ke2e-test-designer when new tests need to be designed.
+tools: Read, Glob, Grep
+model: haiku
+color: blue
+permissionMode: bypassPermissions
+---
+
+# E2E Test Scout
+
+## Role
+
+You search existing E2E tests and match them to validation needs. You are invoked during kbuild VALIDATION tasks to determine what tests should validate a milestone.
+
+**You DO:**
+- Load and search the ke2e skill catalog
+- Match validation requirements to existing tests
+- Identify gaps in coverage
+- Hand off to ke2e-test-designer when new tests are needed
+
+**You DO NOT:**
+- Design new tests (hand off to ke2e-test-designer)
+- Execute tests (that's ke2e-test-runner)
+- Create test files
+- Modify code
+- Run bash commands (read-only research)
+
+---
+
+## Input Format
+
+You receive validation requirements from kbuild:
+
+```markdown
+## E2E Test Scout Request
+
+**Milestone:** M3 - Data Pipeline
+**Capability:** User can trigger a full processing cycle and see results
+
+**Validation Requirements:**
+1. Processing endpoint accepts input and returns results
+2. Output state reflects completed processing
+3. API endpoints respond with correct status
+
+**Components Involved:**
+- ProcessingService
+- APIRouter
+- StateManager
+
+**Intent:** Verify the data pipeline works end-to-end after implementation
+```
+
+---
+
+## Process
+
+### 1. Load the Skill
+
+Read `.claude/skills/ke2e/SKILL.md` to get:
+- Test catalog (what tests exist)
+- Test categories and domains
+- Pre-flight modules available
+
+If the project has a local `.claude/skills/ke2e/` with test recipes, read the catalog table. If only the global version exists, the catalog will be empty.
+
+### 2. Analyze Requirements
+
+For each validation requirement:
+- What capability needs to be tested?
+- What components are involved?
+- What would "passing" look like?
+
+### 3. Search Catalog
+
+Read test files in `.claude/skills/ke2e/tests/` and look for tests that:
+- Cover the same components
+- Validate similar capabilities
+- Can be reused or extended
+
+**Matching approach:**
+- By category directory (e.g., `workflow/`, `api/`, `infrastructure/`)
+- By capability keywords in test purpose/description
+- By component names mentioned in test steps
+
+### 4. Match or Hand Off
+
+**If exact match exists:**
+- Return the test reference
+- Explain what it covers
+- Note any minor gaps
+
+**If partial match exists:**
+- Return the existing test
+- Specify what's covered vs. gaps
+- Suggest extending if gaps are small
+
+**If no match exists:**
+- Return structured handoff for ke2e-test-designer
+- Include all context needed for test design
+
+---
+
+## Output Format
+
+### When Match Found
+
+```markdown
+## E2E Test Recommendations for [Milestone]
+
+### Existing Tests That Apply
+
+| Test | Purpose | Covers Requirement |
+|------|---------|-------------------|
+| workflow/core-cycle | Verify full processing cycle | Requirement 1 |
+| infrastructure/health-endpoint | Verify API responds | Requirement 3 |
+
+**Coverage Notes:**
+- workflow/core-cycle validates the processing path end-to-end
+- infrastructure/health-endpoint checks API liveness
+
+### Gaps Identified
+
+**Requirements not covered:** 2 (output state)
+**Suggestion:** Invoke ke2e-test-designer for output state verification test
+```
+
+### When No Match Found (Designer Handoff)
+
+```markdown
+## E2E Test Recommendations for [Milestone]
+
+### Existing Tests That Apply
+
+None - no existing tests cover this capability.
+
+### Designer Handoff Required
+
+**Invoke ke2e-test-designer with the following context:**
+
+---
+
+## New Test Design Request
+
+**Milestone:** [from input]
+**Capability:** [from input]
+
+**Validation Requirements:**
+[copy from input]
+
+**Components Involved:**
+[copy from input]
+
+**Available Building Blocks:**
+- preflight/common.md (Docker, API health, sandbox detection)
+- [list other relevant modules from catalog]
+
+**Similar Tests for Reference:**
+- [nearest test in catalog, even if not a match]
+- [explain what's different about this requirement]
+```
+
+---
+
+## Key Behaviors
+
+### Be Specific About Coverage
+
+- BAD: "Use workflow/core-cycle"
+- GOOD: "workflow/core-cycle validates POST /process returns 200 with result_id (Req 1). Does NOT validate output state persistence (Req 2)."
+
+### Prefer Existing Tests
+
+- If existing test covers 80%+, suggest using it
+- Only hand off to designer when truly no match exists
+
+### Prepare Rich Handoffs
+
+When handing off to designer, include:
+- All original context (don't lose information)
+- Available building blocks from catalog
+- Similar tests for reference (even imperfect matches)
+- What makes this requirement different

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-# install.sh — Symlink devops-ai skills and rules to AI tool directories
+# install.sh — Symlink devops-ai skills, agents, and rules to AI tool directories
 #
 # Usage: ./install.sh [--force] [--target claude|codex|copilot|all] [--rules <project-path>]
 #
 # Creates directory symlinks from ~/.<tool>/skills/<name>/ → devops-ai/skills/<name>/
-# so that AI tools discover and invoke devops-ai skills natively.
+# and file symlinks from ~/.<tool>/agents/<name>.md → devops-ai/agents/<name>.md
+# so that AI tools discover and invoke devops-ai skills and agents natively.
 #
 # Running 'git pull' in devops-ai updates all symlinked skills globally.
 
@@ -12,6 +13,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$SCRIPT_DIR/skills"
+AGENTS_DIR="$SCRIPT_DIR/agents"
 RULES_DIR="$SCRIPT_DIR/rules"
 FORCE=false
 TARGET="all"
@@ -101,6 +103,45 @@ install_rules() {
     echo "  → $count rules installed to $rules_target"
 }
 
+install_agents() {
+    local target_dir="$1"
+    local tool_name="$2"
+    [ -d "$AGENTS_DIR" ] || return 0
+    mkdir -p "$target_dir"
+
+    # Clean stale agent symlinks
+    for link in "$target_dir"/*.md; do
+        [ -L "$link" ] || continue
+        if [ ! -e "$link" ]; then
+            echo "  CLEAN: $(basename "$link") (stale symlink)"
+            rm -f "$link"
+        fi
+    done
+
+    local count=0
+    for agent in "$AGENTS_DIR"/*.md; do
+        [ -f "$agent" ] || continue
+        local name
+        name=$(basename "$agent")
+        local target="$target_dir/$name"
+
+        if [ -e "$target" ] && [ ! -L "$target" ]; then
+            if [ "$FORCE" = true ]; then
+                rm -f "$target"
+            else
+                echo "  SKIP: $name (non-symlink exists, use --force to overwrite)"
+                continue
+            fi
+        fi
+
+        ln -sfn "$agent" "$target"
+        echo "  OK: $name"
+        count=$((count + 1))
+    done
+
+    echo "  → $count agents installed for $tool_name"
+}
+
 # Handle --rules mode
 if [ -n "$RULES_PROJECT" ]; then
     if [ ! -d "$RULES_PROJECT" ]; then
@@ -137,8 +178,10 @@ echo ""
 
 # Claude Code
 if [ "$TARGET" = "all" ] || [ "$TARGET" = "claude" ]; then
-    echo "Claude Code:"
+    echo "Claude Code (skills):"
     install_skills "$HOME/.claude/skills" "Claude Code"
+    echo "Claude Code (agents):"
+    install_agents "$HOME/.claude/agents" "Claude Code"
     echo ""
 fi
 

--- a/rules/e2e-testing.md
+++ b/rules/e2e-testing.md
@@ -33,7 +33,9 @@ E2E test results should include concrete evidence: API responses, log excerpts, 
 
 ## Per-project test catalog
 
-Projects with recurring E2E patterns should maintain a test catalog (location defined in project config). Before designing a new E2E test, check the catalog — reuse existing tests where they apply. When designing a new reusable test, add it to the catalog for future use.
+The `/ke2e` skill and agents (ke2e-test-scout, ke2e-test-designer, ke2e-test-runner) provide the full E2E testing workflow. Test recipes live at `.claude/skills/ke2e/tests/` per project and grow organically as milestones are validated.
+
+Before designing a new E2E test, the scout agent searches the catalog for existing recipes. When no match exists, the designer agent creates a new recipe. The runner agent executes recipes against the real sandbox and reports PASS/FAIL with evidence and failure categorization.
 
 ## Integration with milestones
 

--- a/skills/kbuild/SKILL.md
+++ b/skills/kbuild/SKILL.md
@@ -66,7 +66,11 @@ Implementation plans contain code samples that show patterns and wiring — not 
 - **CODING** — TDD required. Write tests first, then implementation, then refactor.
 - **RESEARCH** — Investigation, analysis, documentation. No TDD.
 - **MIXED** — Research first, then TDD for the implementation portion.
-- **VALIDATION** — E2E test execution. Exercise real system flows, report results with evidence. See the `e2e-testing` rule for what "real E2E" means.
+- **VALIDATION** — Real E2E tests required against the running sandbox. Follow this sequence:
+  1. Invoke the **ke2e-test-scout** agent with the milestone's validation requirements. The scout searches the ke2e test catalog (`.claude/skills/ke2e/tests/`) and returns matching recipes or hands off to **ke2e-test-designer** for new recipe creation.
+  2. Invoke the **ke2e-test-runner** agent with the identified test recipes. The runner executes pre-flight checks, runs test steps against the sandbox, and reports PASS/FAIL with evidence and failure categorization.
+  3. Do NOT write pytest code for E2E validation — use catalog recipes executed by the runner agent.
+  4. If you catch yourself writing `@pytest.mark.mock` or seeding data instead of calling real services, stop: that is an integration test, not E2E.
 
 ---
 
@@ -92,6 +96,13 @@ This is the single most consistently useful artifact across sessions. Create `HA
 
 When all tasks in a milestone are done, produce this summary. This is an interface contract used for PR creation — do not skip it.
 
+**Before writing the report**, verify the E2E table by answering these questions for each test listed:
+1. Did this test make real external calls (API, database, container)?
+2. Did you actually run it with real credentials and see it pass?
+3. If it uses `@pytest.mark.mock`, seeded data, or mocked externals — it is NOT E2E. Classify it as integration.
+
+Tests that don't make real external calls MUST NOT appear in the E2E table. Put them in a separate "Integration Tests" section. Misclassifying integration tests as E2E is an untruthful report.
+
 ```markdown
 ## Milestone Complete: [Name]
 
@@ -99,10 +110,18 @@ When all tasks in a milestone are done, produce this summary. This is an interfa
 **Quality gates:** All passed
 
 ### E2E Tests Performed
+<!-- Every test here MUST have made real external calls -->
+<!-- If a test uses mocks or seeded data, move it to Integration Tests -->
 
-| Test | Steps | Result |
-|------|-------|--------|
-| [test-name] | N | PASSED/FAILED |
+| Test | What it exercises (real calls to...) | Result |
+|------|--------------------------------------|--------|
+| [test-name] | [e.g. "real Anthropic API via op run"] | PASSED/FAILED |
+
+### Integration Tests
+
+| Test | Result |
+|------|--------|
+| [test-name] | PASSED/FAILED |
 
 ### Challenges & Solutions
 
@@ -115,9 +134,24 @@ When all tasks in a milestone are done, produce this summary. This is an interfa
 | Test | Failure | Status |
 |------|---------|--------|
 | [test] | [description] | Pre-existing / Flaky |
+
+### E2E Catalog Tests Executed
+<!-- Recipes from .claude/skills/ke2e/tests/ executed by ke2e-test-runner -->
+
+| Recipe | Result | Category (if failed) |
+|--------|--------|---------------------|
+| [category/name] | PASSED/FAILED | [ENVIRONMENT/CONFIGURATION/CODE_BUG/TEST_ISSUE] |
+
+### E2E Gate
+<!-- This section is REQUIRED. If empty, the milestone is NOT complete. -->
+- [ ] ke2e-test-scout invoked with milestone validation requirements
+- [ ] ke2e-test-runner invoked with test recipes
+- [ ] All recipes PASSED or failures categorized with remediation
+- [ ] No ENVIRONMENT failures remaining (environment must be stable)
 ```
 
-If no E2E tests in the milestone, state "No E2E tests in this milestone."
+If no catalog recipes exist for this milestone's changes, invoke ke2e-test-scout to confirm and document the gap — do NOT simply state "No E2E tests."
+If no integration tests, omit that section.
 If no challenges, state "No significant challenges encountered."
 If all test failures addressed, state "All test failures were addressed."
 

--- a/skills/ke2e/FAILURE_CATEGORIES.md
+++ b/skills/ke2e/FAILURE_CATEGORIES.md
@@ -1,0 +1,137 @@
+# E2E Test Failure Categories
+
+When a test fails, categorize it to guide the main agent's response.
+
+---
+
+## Categories
+
+### ENVIRONMENT
+
+**Definition:** Failure due to infrastructure, not code or configuration.
+
+**Examples:**
+- Docker not running or container crashed
+- Service not responding after cure attempts
+- Network connectivity issues (external APIs, OTEL endpoint)
+- Disk space issues in container
+
+**Main Agent Action:** Ask human for help (can't fix via code)
+
+**Report Format:**
+```markdown
+**Category:** ENVIRONMENT
+**Diagnosis:** [Infrastructure issue description]
+**Suggested Action:** Manual intervention required. [Specific steps]
+```
+
+---
+
+### CONFIGURATION
+
+**Definition:** Failure due to missing env vars, wrong paths, or service config.
+
+**Examples:**
+- API key not injected (503 from API)
+- Wrong port (testing against production)
+- Config file missing required field
+- Secret reference not resolving
+
+**Main Agent Action:** Fix configuration, re-run test
+
+**Report Format:**
+```markdown
+**Category:** CONFIGURATION
+**Diagnosis:** [What's misconfigured and why it matters]
+**Suggested Action:** [Specific configuration change needed]
+```
+
+---
+
+### CODE_BUG
+
+**Definition:** Failure due to bug in implementation code.
+
+**Examples:**
+- API returns 500 error
+- Exception in service layer (stack trace in logs)
+- Wrong status returned from endpoint
+- State not written after operation
+- Tracking/audit log empty when it should have entries
+- Cost/usage tracking shows zero when processing occurred
+
+**Main Agent Action:** Fix code, re-run test
+
+**Report Format:**
+```markdown
+**Category:** CODE_BUG
+**Diagnosis:** [What code is broken and symptoms]
+**Suggested Action:** [Where to look, what to fix]
+**Evidence:** [Stack traces, error messages, logs]
+```
+
+---
+
+### TEST_ISSUE
+
+**Definition:** Failure due to problem with test recipe itself.
+
+**Examples:**
+- Test checks wrong endpoint (API changed)
+- Success criteria incorrect
+- Sanity check threshold too tight
+- Test assumes wrong initial state
+
+**Main Agent Action:** Fix test recipe, re-run test
+
+**Report Format:**
+```markdown
+**Category:** TEST_ISSUE
+**Diagnosis:** [What's wrong with the test]
+**Suggested Action:** [How to fix the test recipe]
+```
+
+---
+
+## Category Decision Tree
+
+```
+Test failed
+    |
+    +-- Pre-flight failed after all cures?
+    |       -> ENVIRONMENT
+    |
+    +-- 503 from API / missing env var?
+    |       -> CONFIGURATION
+    |
+    +-- API error (500) or exception in logs?
+    |       -> CODE_BUG
+    |
+    +-- Test passed but sanity check failed?
+    |       |
+    |       +-- Zero cost/usage after real processing?
+    |       |       -> CODE_BUG (tracking broken)
+    |       |
+    |       +-- Response time anomaly (instant return)?
+    |       |       -> CODE_BUG (request not processed)
+    |       |
+    |       +-- Audit/state files empty or unchanged?
+    |               -> CODE_BUG (persistence broken)
+    |
+    +-- Test expectations seem wrong?
+            -> TEST_ISSUE
+```
+
+---
+
+## Common Failure Patterns
+
+| Symptom | Likely Category | Why |
+|---------|-----------------|-----|
+| Connection refused on port | ENVIRONMENT | Container not running |
+| 503 from any endpoint | CONFIGURATION | API key not injected |
+| 500 from endpoint | CODE_BUG | Exception in service code |
+| State file not found after operation | CODE_BUG | Persistence not working |
+| Zero cost after real API call | CODE_BUG | Cost tracking broken |
+| Test expects field that doesn't exist | TEST_ISSUE | API schema changed |
+| Timeout on cold start | TEST_ISSUE | Timeout too short |

--- a/skills/ke2e/SKILL.md
+++ b/skills/ke2e/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: ke2e
+description: Knowledge base for E2E test design and execution against project sandboxes. Used by ke2e-test-scout (catalog lookup), ke2e-test-designer (new test design), and ke2e-test-runner (execution) agents.
+metadata:
+  version: "1.0.0"
+---
+
+# E2E Testing Skill
+
+## Purpose
+
+Knowledge base for E2E test design and execution. Used by:
+- **ke2e-test-scout** agent — Fast catalog lookup during planning
+- **ke2e-test-designer** agent — Design new tests when no match exists
+- **ke2e-test-runner** agent — Execute tests and report results
+
+## Agents
+
+| Agent | Model | Purpose | When Invoked |
+|-------|-------|---------|--------------|
+| ke2e-test-scout | haiku | Find existing tests, identify gaps | During kbuild VALIDATION tasks |
+| ke2e-test-designer | opus | Design new tests from scratch | When scout finds no match |
+| ke2e-test-runner | sonnet | Execute tests, report results | After scout/designer identify tests |
+
+## How Tests Are Designed
+
+```
+kbuild (VALIDATION task)
+    |
+    v
+ke2e-test-scout (haiku) --- catalog lookup
+    |
+    +-- match found --> return recommendation
+    |
+    +-- no match --> ke2e-test-designer (opus)
+                          |
+                          v
+                    new test recipe written to catalog
+```
+
+### ke2e-test-scout (haiku) - Catalog Lookup
+
+1. Receives validation requirements from kbuild
+2. Loads this skill's catalog
+3. Searches for matching tests using category, capability, and keyword heuristics
+4. Returns recommendations OR hands off to designer
+
+### ke2e-test-designer (opus) - New Test Design
+
+1. Receives handoff from scout when no match exists
+2. Reads `.devops-ai/infra.toml` for sandbox configuration
+3. Analyzes requirements deeply (edge cases, false positives, sanity checks)
+4. Designs comprehensive test recipe using [TEMPLATE.md](TEMPLATE.md)
+5. Writes reusable tests to `.claude/skills/ke2e/tests/{category}/{name}.md`
+
+**Why two agents?** Catalog lookup is mechanical (haiku is fast/cheap). Designing new tests requires reasoning about validation, false positives, and edge cases (opus provides quality).
+
+## How Tests Are Executed
+
+The ke2e-test-runner agent:
+1. Loads this skill (SKILL.md)
+2. Finds requested tests in the catalog
+3. Loads test recipe files
+4. Runs pre-flight checks with cure loops
+5. Executes test steps via curl and docker exec
+6. Reports PASS/FAIL with evidence and failure categorization
+
+## Test Catalog
+
+Your project's catalog lives at `.claude/skills/ke2e/tests/`. Tests are added by the ke2e-test-designer agent and grow organically as milestones are validated.
+
+**To populate:** When the scout finds no matching test, the designer creates one. Over time, the catalog covers the project's key user scenarios.
+
+**Catalog structure:**
+```
+.claude/skills/ke2e/tests/
+  <category>/
+    <test-name>.md
+```
+
+Categories are project-specific (e.g., `workflow/`, `api/`, `infrastructure/`, `data-pipeline/`).
+
+<!-- When tests exist, add a catalog table here:
+| Test | Category | Duration | Use When |
+|------|----------|----------|----------|
+| category/name | Category | ~Xs | Description |
+-->
+
+## Pre-Flight Modules
+
+| Module | Checks | Used By |
+|--------|--------|---------|
+| [common](preflight/common.md) | Docker, sandbox port, API health | All tests |
+
+Project-specific preflight modules can be added to `.claude/skills/ke2e/preflight/` (e.g., for checking external service connectivity, database readiness, or session warmup).
+
+## Troubleshooting
+
+| Domain | Module | Common Issues |
+|--------|--------|---------------|
+| [Common](troubleshooting/common.md) | General | Timeouts, cold start, schema changes, port confusion |
+
+## Creating New Tests
+
+Use [TEMPLATE.md](TEMPLATE.md) when creating new test recipes. See [FAILURE_CATEGORIES.md](FAILURE_CATEGORIES.md) for categorizing failures.
+
+## What "Real E2E" Means
+
+E2E tests make real calls against a running sandbox container. Not mocked. Not "integration with mocks."
+
+- Real API calls to container endpoints (curl, httpx)
+- Real processing inside the container
+- Real state changes observed via docker exec or API response
+- Observable outcomes asserted on real data
+
+Integration tests with mocked externals are NOT E2E. Never label them as such.
+
+## Sandbox Configuration
+
+E2E tests run against a kinfra-managed sandbox. Configuration comes from `.devops-ai/infra.toml`:
+
+```toml
+[sandbox.ports]
+API_PORT = 8000              # Port variable name and default
+
+[sandbox.health]
+endpoint = "/health"         # Health check path
+port_var = "API_PORT"        # Which port var to use for health checks
+```
+
+```bash
+# Find your sandbox
+kinfra status
+
+# Start/rebuild sandbox
+kinfra sandbox start
+
+# Run tests (set port var to sandbox port, not production)
+<PORT_VAR>=<sandbox_port> ke2e-test-runner <test-name>
+```
+
+**Never test against the production port.** Sandbox port = base + slot_id (e.g., 8000 + 1 = 8001).

--- a/skills/ke2e/TEMPLATE.md
+++ b/skills/ke2e/TEMPLATE.md
@@ -1,0 +1,89 @@
+# Test: {category}/{name}
+
+**Purpose:** [One sentence describing what this test validates — a user scenario, not a technical detail]
+**Duration:** [Expected time]
+**Category:** [Project-specific category]
+
+---
+
+## Pre-Flight Checks
+
+**Required modules:**
+- [common](../preflight/common.md)
+- [Add domain-specific if needed]
+
+**Test-specific checks:**
+- [ ] [Any checks unique to this test]
+
+---
+
+## Test Data
+
+```json
+{
+  "REPLACE": "with actual request payload"
+}
+```
+
+**Why this data:** [Explain parameter choices]
+
+---
+
+## Execution Steps
+
+### 1. [Step Name]
+
+**Command:**
+```bash
+curl -s -X POST http://localhost:${PORT_VAR}/endpoint \
+  -H "Content-Type: application/json" \
+  -d '{"key": "value"}'
+```
+
+**Expected:**
+- [What should happen — describe the user-visible outcome]
+
+### 2. [Next Step]
+...
+
+---
+
+## Success Criteria
+
+- [ ] [Observable business outcome 1]
+- [ ] [Observable business outcome 2]
+
+---
+
+## Sanity Checks
+
+**CRITICAL:** These catch false positives
+
+- [ ] [Sanity check 1 with threshold — e.g., "cost_usd > 0 proves real processing occurred"]
+- [ ] [Sanity check 2 — e.g., "response time > 1s proves request wasn't short-circuited"]
+
+---
+
+## Troubleshooting
+
+**If [symptom]:**
+- **Cause:** [Why this happens]
+- **Category:** [ENVIRONMENT | CONFIGURATION | CODE_BUG | TEST_ISSUE]
+- **Cure:** [How to fix]
+
+---
+
+## Evidence to Capture
+
+- Response body: [Key fields to save]
+- Container state: `docker exec $CONTAINER sh -c "[command]"`
+- Logs: `docker compose logs <service> --since 5m | grep {pattern}`
+
+---
+
+## Notes
+
+- **Port variable:** Read from `.devops-ai/infra.toml` `[sandbox.health].port_var` — never hardcode ports.
+- **Container discovery:** Use `docker ps --filter "name=${PROJECT}-slot" --format "{{.Names}}" | head -1` — never hardcode container names.
+- **Non-determinism:** If the service involves LLM calls, assert on structure (fields present, status codes) rather than exact content.
+- **Sandbox port:** Always use the port variable from infra.toml — never the production default.

--- a/skills/ke2e/TEMPLATE.md
+++ b/skills/ke2e/TEMPLATE.md
@@ -35,7 +35,7 @@
 
 **Command:**
 ```bash
-curl -s -X POST http://localhost:${PORT_VAR}/endpoint \
+curl -s -X POST http://localhost:${API_PORT}/endpoint \
   -H "Content-Type: application/json" \
   -d '{"key": "value"}'
 ```

--- a/skills/ke2e/preflight/common.md
+++ b/skills/ke2e/preflight/common.md
@@ -1,0 +1,189 @@
+# Pre-Flight: Common Checks
+
+**Used by:** All E2E tests
+**Purpose:** Verify basic environment is healthy before running any test
+
+---
+
+## Configuration Discovery
+
+Before running checks, read the project's `.devops-ai/infra.toml` to determine:
+
+- **Port variable name:** `[sandbox.health].port_var` (e.g., `API_PORT`)
+- **Default port:** `[sandbox.ports].<port_var>` (e.g., `8000`)
+- **Health endpoint:** `[sandbox.health].endpoint` (e.g., `/health`)
+- **Project name:** `[project].name` (e.g., `myproject`)
+
+Use these values in the checks below. Do not hardcode project-specific values.
+
+---
+
+## Checks
+
+### 1. Sandbox Port Detection
+
+**Command:**
+```bash
+# PORT_VAR and DEFAULT_PORT come from infra.toml
+API_PORT=${!PORT_VAR:-$DEFAULT_PORT}
+
+if [ "$API_PORT" = "$DEFAULT_PORT" ] && [ -z "${!PORT_VAR:-}" ]; then
+  echo "FAIL: $PORT_VAR not set — refusing to test against production ($DEFAULT_PORT)."
+  echo "Set $PORT_VAR to your sandbox port before running tests."
+  echo "  Run: kinfra status  # to find your sandbox port"
+  exit 1
+fi
+
+echo "OK: Using $PORT_VAR=$API_PORT"
+```
+
+**Pass if:** Port variable is set to a non-default value (sandbox port = base + slot_id)
+
+**Fail message:** "[PORT_VAR] not set — refusing to test against production"
+
+---
+
+### 2. Docker Container Running
+
+**Command:**
+```bash
+# PROJECT comes from infra.toml [project].name
+CONTAINER=$(docker ps --filter "name=${PROJECT}-slot" --format "{{.Names}}" | head -1)
+if [ -z "$CONTAINER" ]; then
+  echo "FAIL: No ${PROJECT}-slot container running"
+  docker ps --filter "name=${PROJECT}" --format "table {{.Names}}\t{{.Status}}"
+  exit 1
+fi
+echo "OK: Container running: $CONTAINER"
+```
+
+**Pass if:** A container matching `${PROJECT}-slot*` is running
+
+**Fail message:** "No ${PROJECT} sandbox container running"
+
+---
+
+### 3. API Health
+
+**Command:**
+```bash
+# HEALTH_ENDPOINT comes from infra.toml [sandbox.health].endpoint
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  http://localhost:${API_PORT}${HEALTH_ENDPOINT} 2>/dev/null || echo "000")
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "FAIL: API not responding (HTTP $HTTP_CODE) on port $API_PORT"
+  exit 1
+fi
+echo "OK: API healthy on port $API_PORT"
+```
+
+**Pass if:** Health endpoint returns HTTP 200
+
+**Fail message:** "API not responding on port $API_PORT"
+
+---
+
+## Quick Check Script
+
+Run all checks at once (substitute values from infra.toml):
+
+```bash
+#!/bin/bash
+set -e
+
+# Read these from .devops-ai/infra.toml
+PORT_VAR="API_PORT"          # [sandbox.health].port_var
+DEFAULT_PORT="8000"          # [sandbox.ports].$PORT_VAR
+HEALTH_ENDPOINT="/health"   # [sandbox.health].endpoint
+PROJECT="myproject"          # [project].name
+
+API_PORT=${!PORT_VAR:-$DEFAULT_PORT}
+
+echo "=== Pre-Flight: Common Checks ==="
+
+# Check 1: Sandbox port
+if [ "$API_PORT" = "$DEFAULT_PORT" ] && [ -z "${!PORT_VAR:-}" ]; then
+  echo "FAIL: $PORT_VAR not set or is $DEFAULT_PORT (production). Set it to your sandbox port."
+  echo "  Run: kinfra status  # to find your sandbox port"
+  exit 1
+fi
+echo "OK: Using sandbox port $API_PORT"
+
+# Check 2: Docker container
+CONTAINER=$(docker ps --filter "name=${PROJECT}-slot" --format "{{.Names}}" | head -1)
+if [ -z "$CONTAINER" ]; then
+  echo "FAIL: No ${PROJECT} sandbox container running"
+  docker ps --filter "name=${PROJECT}" --format "table {{.Names}}\t{{.Status}}"
+  exit 1
+fi
+echo "OK: Container running: $CONTAINER"
+
+# Check 3: API health
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  http://localhost:$API_PORT${HEALTH_ENDPOINT} 2>/dev/null || echo "000")
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "FAIL: API not responding (HTTP $HTTP_CODE) on port $API_PORT"
+  exit 1
+fi
+echo "OK: API healthy on port $API_PORT"
+
+echo "=== All pre-flight checks passed ==="
+```
+
+---
+
+## Symptom -> Cure Mappings
+
+### Container Not Running
+
+**Symptom:** "No ${PROJECT} sandbox container running" or `docker ps` shows no matching containers
+
+**Cause:** Container crashed, not started, or kinfra slot not provisioned
+
+**Cure:**
+```bash
+kinfra sandbox start
+```
+
+**Max Retries:** 2
+**Wait After Cure:** 30 seconds (container needs time to start and pass health check)
+
+---
+
+### API Not Responding
+
+**Symptom:** Health check returns non-200 or connection refused
+
+**Cause:** Container starting up, crashed internally, or wrong port
+
+**Cure:**
+```bash
+CONTAINER=$(docker ps -a --filter "name=${PROJECT}-slot" --format "{{.Names}}" | head -1)
+if [ -n "$CONTAINER" ]; then
+  docker restart "$CONTAINER"
+else
+  kinfra sandbox start
+fi
+```
+
+**Max Retries:** 2
+**Wait After Cure:** 15 seconds
+
+---
+
+### Wrong Port (Testing Against Production)
+
+**Symptom:** Port variable not set or equals production default
+
+**Cause:** Environment variable not set, forgot to source sandbox config
+
+**Cure:**
+```bash
+# Find sandbox port from kinfra
+kinfra status
+# Look for the port var and export it:
+# export PORT_VAR=<sandbox_port>
+```
+
+**Max Retries:** 1 (config issue — if this doesn't work, human must intervene)
+**Wait After Cure:** 0 seconds (config only, no service restart)

--- a/skills/ke2e/preflight/common.md
+++ b/skills/ke2e/preflight/common.md
@@ -181,8 +181,9 @@ fi
 ```bash
 # Find sandbox port from kinfra
 kinfra status
-# Look for the port var and export it:
-# export PORT_VAR=<sandbox_port>
+# Using the port variable name from [sandbox.health].port_var in infra.toml,
+# export the actual env var with the sandbox port, for example:
+# export API_PORT=<sandbox_port>
 ```
 
 **Max Retries:** 1 (config issue — if this doesn't work, human must intervene)

--- a/skills/ke2e/troubleshooting/common.md
+++ b/skills/ke2e/troubleshooting/common.md
@@ -1,0 +1,95 @@
+# Troubleshooting: Common Issues
+
+## Cold Start Timeout
+
+**Symptom:** First request takes very long or times out
+
+**Why:** First request on a fresh container may trigger initialization: dependency loading, config reading, warm-up processing. Services backed by LLMs can take 200-400+ seconds for cold start.
+
+**Fixes:**
+- Use a session warmup preflight module to absorb cold start cost before timing-sensitive tests
+- Set timeout appropriately for cold-start-expected tests (e.g., 600s)
+- After first request, subsequent requests should be fast
+
+---
+
+## API Schema Changes
+
+**Symptom:** Test expects a field that doesn't exist, or field has unexpected type
+
+**Why:** API response schema changed since test recipe was written.
+
+**Fixes:**
+1. Check current API endpoints in the project source code
+2. Update test recipe with correct field names
+3. Category: TEST_ISSUE
+
+---
+
+## Container Name Mismatch
+
+**Symptom:** `docker exec` commands fail with "No such container"
+
+**Why:** Container name depends on kinfra slot: `${PROJECT}-slot-{N}-{service}-1`
+
+**Fixes:**
+- Always discover container dynamically:
+  ```bash
+  CONTAINER=$(docker ps --filter "name=${PROJECT}-slot" --format "{{.Names}}" | head -1)
+  ```
+- Never hardcode container names in test recipes
+
+---
+
+## Port Confusion (Sandbox vs Production)
+
+**Symptom:** Test passes but changes aren't reflected, or test affects production
+
+**Why:** Testing against the production/default port instead of sandbox port
+
+**Fixes:**
+- Always set the port variable (from infra.toml) before running tests
+- `kinfra status` shows your sandbox port
+- Production = default port, sandbox = default + slot_id
+
+---
+
+## Stale State After Code Change
+
+**Symptom:** Test passes but behavior doesn't reflect code changes
+
+**Why:** Container is running the old code. Code changes require container rebuild.
+
+**Fixes:**
+1. Rebuild sandbox: `kinfra sandbox start`
+2. Wait for container to be healthy
+3. First request may be a cold start
+
+---
+
+## Permission Denied in Container
+
+**Symptom:** docker exec commands fail with permission errors
+
+**Why:** File ownership issues inside container (root vs app user)
+
+**Fixes:**
+```bash
+CONTAINER=$(docker ps --filter "name=${PROJECT}-slot" --format "{{.Names}}" | head -1)
+docker exec "$CONTAINER" sh -c "ls -la /path/to/data/"
+# If permission issue, container rebuild usually fixes it
+kinfra sandbox start
+```
+
+---
+
+## Health Check Passes But Feature Broken
+
+**Symptom:** Pre-flight passes, but actual test steps fail
+
+**Why:** Health endpoint only checks basic liveness, not feature-level readiness
+
+**Fixes:**
+- Add test-specific pre-flight checks for the feature being tested
+- Check dependent services (database, external APIs, message queues)
+- Look at container logs: `docker compose logs <service> --tail 30`

--- a/skills/kplan/SKILL.md
+++ b/skills/kplan/SKILL.md
@@ -95,9 +95,15 @@ For tasks touching multiple categories (persistence, wiring, state machines, etc
 
 Every milestone ends with a VALIDATION task. This is a structural requirement, not optional.
 
-The VALIDATION task exercises the real system end-to-end to verify the milestone works as designed. The `e2e-testing` rule defines what "real E2E" means and what makes a valid validation.
+The VALIDATION task must include these instructions in its description — they will be read by `/kbuild` at execution time:
 
-A validation that only checks "does it start" is insufficient. Valid tests exercise real operational flows with verifiable outcomes.
+1. **Load the `ke2e` skill** before designing any validation
+2. **Invoke ke2e-test-scout** with the milestone's validation requirements — the scout searches the test catalog and returns matching recipes or hands off to ke2e-test-designer
+3. **Invoke ke2e-test-runner** with the identified test recipes — the runner executes pre-flight checks, runs steps against the real sandbox, and reports PASS/FAIL with evidence
+4. **Tests must exercise real running infrastructure** — real API calls to real containers, real state changes, observable outcomes
+5. **Tests that use mocks or seeded data without real external calls are integration tests, not E2E** — write those too if useful, but they do not satisfy the validation requirement
+
+A validation that only checks "does it start" is insufficient. A validation that seeds data and checks logic without real external calls is an integration test, not E2E. Valid E2E tests exercise real operational flows through real external systems with verifiable outcomes.
 
 ---
 

--- a/templates/project-config.md
+++ b/templates/project-config.md
@@ -32,8 +32,8 @@ Not configured.
 Not configured.
 
 <!-- If your project uses E2E testing, replace above with:
-- **System:** [agent / manual / framework-name]
-- **Test catalog:** [path to test catalog]
+- **E2E tests:** [start command, e.g., "kinfra sandbox start"]
+- **Test catalog:** .claude/skills/ke2e/tests/
 -->
 
 ## Paths


### PR DESCRIPTION
## Summary

- Extracts the production-grade E2E testing system built in agent-memory into devops-ai for use by all kinfra-managed projects
- Three specialized agents: **ke2e-test-scout** (haiku, catalog search), **ke2e-test-designer** (opus, new test design), **ke2e-test-runner** (sonnet, execution with cure loops)
- Shared skill framework with recipe templates, failure categorization decision tree, preflight checks with symptom→cure mappings, and troubleshooting guides
- Agents read project config from `infra.toml` at runtime — no hardcoded project-specific values
- `install.sh` now distributes agents to `~/.claude/agents/` alongside skills

## What changed

| Area | Files | Change |
|------|-------|--------|
| New skill | `skills/ke2e/` (5 files) | Shared framework: SKILL.md, TEMPLATE.md, FAILURE_CATEGORIES.md, preflight, troubleshooting |
| New agents | `agents/` (3 files) | Scout, designer, runner agent definitions |
| Distribution | `install.sh` | `install_agents()` function, stale symlink cleanup |
| Build pipeline | `skills/kbuild/SKILL.md` | VALIDATION tasks invoke scout→designer→runner workflow, improved E2E/integration table split |
| Plan pipeline | `skills/kplan/SKILL.md` | VALIDATION tasks reference ke2e agents |
| Rule | `rules/e2e-testing.md` | References ke2e system and test catalog |
| Template | `templates/project-config.md` | Updated E2E section |

## How it works

```
kbuild VALIDATION task
  → ke2e-test-scout (haiku): searches .claude/skills/ke2e/tests/ catalog
  → if no match: ke2e-test-designer (opus) designs new recipe
  → ke2e-test-runner (sonnet): executes recipe against real sandbox
  → reports PASS/FAIL with evidence, failure categorization, cure attempts
```

Per-project catalogs grow organically — the designer creates recipes during milestone validation, the scout reuses them in future milestones.

## Test plan

- [x] `./install.sh` creates `~/.claude/skills/ke2e` symlink and `~/.claude/agents/ke2e-*.md` symlinks
- [x] All 271 unit tests pass
- [x] Pre-commit hooks pass (ruff + mypy + tests)
- [ ] Validate ke2e skill loads in Claude Code session (visible in skill list)
- [ ] Test scout/designer/runner workflow on a real project milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)