### PR TITLE
fix: sandbox lifecycle reliability and skill drift guard

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,65 @@ case "$TARGET" in
     *) echo "Error: Invalid target '$TARGET'. Allowed values: claude, codex, copilot, all."; exit 1 ;;
 esac
 
+# ---------------------------------------------------------------------------
+# Skill reconciliation — detect drift before overwriting
+# ---------------------------------------------------------------------------
+
+check_skill_drift() {
+    local target_dir="$1"
+    local has_drift=false
+
+    # Check 1: Uncommitted changes in devops-ai skills/ (symlinks point here)
+    local dirty_skills
+    dirty_skills=$(git -C "$SCRIPT_DIR" diff --name-only -- skills/ 2>/dev/null || true)
+    if [ -n "$dirty_skills" ]; then
+        echo "  WARNING: Uncommitted skill changes in devops-ai:"
+        echo "$dirty_skills" | while read -r f; do
+            echo "    modified: $f"
+        done
+        has_drift=true
+    fi
+
+    # Check 2: Non-symlink skills at target that differ from devops-ai source
+    if [ -d "$target_dir" ]; then
+        for local_skill in "$target_dir"/*/; do
+            [ -d "$local_skill" ] || continue
+            [ -L "${local_skill%/}" ] && continue  # skip symlinks — they're fine
+            local name
+            name=$(basename "${local_skill%/}")
+            local source_skill="$SKILLS_DIR/$name/SKILL.md"
+            local local_file="${local_skill}SKILL.md"
+            if [ -f "$source_skill" ] && [ -f "$local_file" ]; then
+                if ! diff -q "$source_skill" "$local_file" >/dev/null 2>&1; then
+                    echo "  WARNING: Local skill '$name' differs from devops-ai source"
+                    echo "    local:  $local_file"
+                    echo "    source: $source_skill"
+                    has_drift=true
+                fi
+            elif [ ! -f "$source_skill" ] && [ -f "$local_file" ]; then
+                echo "  INFO: Local-only skill '$name' (not in devops-ai)"
+            fi
+        done
+    fi
+
+    if [ "$has_drift" = true ]; then
+        echo ""
+        echo "  Skill drift detected. To resolve:"
+        echo "    1. Review changes:  git -C $SCRIPT_DIR diff skills/"
+        echo "    2. Commit to keep:  git -C $SCRIPT_DIR add skills/ && git commit"
+        echo "    3. Discard changes: git -C $SCRIPT_DIR checkout skills/"
+        echo "    4. Force install:   ./install.sh --force"
+        echo ""
+        if [ "$FORCE" != true ]; then
+            echo "  Aborting. Use --force to install anyway (uncommitted changes will persist)."
+            return 1
+        else
+            echo "  --force specified, continuing despite drift."
+        fi
+    fi
+    return 0
+}
+
 cleanup_stale_symlinks() {
     local target_dir="$1"
     [ -d "$target_dir" ] || return 0
@@ -173,6 +232,13 @@ if command -v uv &>/dev/null; then
     fi
 else
     echo "  SKIP: uv not found — install uv (https://docs.astral.sh/uv/) for kinfra CLI"
+fi
+echo ""
+
+# Skill drift check (runs once, covers all targets)
+echo "Skill reconciliation:"
+if ! check_skill_drift "$HOME/.claude/skills"; then
+    exit 1
 fi
 echo ""
 

--- a/install.sh
+++ b/install.sh
@@ -235,7 +235,8 @@ else
 fi
 echo ""
 
-# Skill drift check (runs once, covers all targets)
+# Skill drift check — source-level (git status) plus Claude target directory
+# (Claude is the primary target where local-only skills are created)
 echo "Skill reconciliation:"
 if ! check_skill_drift "$HOME/.claude/skills"; then
     exit 1

--- a/skills/kbuild/SKILL.md
+++ b/skills/kbuild/SKILL.md
@@ -67,6 +67,7 @@ Implementation plans contain code samples that show patterns and wiring — not 
 - **RESEARCH** — Investigation, analysis, documentation. No TDD.
 - **MIXED** — Research first, then TDD for the implementation portion.
 - **VALIDATION** — Real E2E tests required against the running sandbox. Follow this sequence:
+  0. **Discover the sandbox** — Run `kinfra status` to find the sandbox port and slot. If the sandbox is not running, run `kinfra sandbox start`. If code has changed since the sandbox was last built, run `kinfra sandbox rebuild` to update the container image. Do NOT skip this step or assume the sandbox is unavailable.
   1. Invoke the **ke2e-test-scout** agent with the milestone's validation requirements. The scout searches the ke2e test catalog (`.claude/skills/ke2e/tests/`) and returns matching recipes or hands off to **ke2e-test-designer** for new recipe creation.
   2. Invoke the **ke2e-test-runner** agent with the identified test recipes. The runner executes pre-flight checks, runs test steps against the sandbox, and reports PASS/FAIL with evidence and failure categorization.
   3. Do NOT write pytest code for E2E validation — use catalog recipes executed by the runner agent.

--- a/skills/kreview/SKILL.md
+++ b/skills/kreview/SKILL.md
@@ -95,7 +95,7 @@ Generate a comparison table showing overlap, unique concerns per reviewer, and c
 
 ## Reviewer Tendencies
 
-**Copilot** tends to suggest combining intentionally separate code, flag "redundancy" that's actually clarity, and miss project-specific patterns.
+**Copilot** has improved significantly — recent reviews consistently catch real bugs (logic errors, race conditions), valid architectural issues (blocking async, unused dependencies), and legitimate consistency problems. Assess each comment on its merits rather than discounting by reviewer.
 
 **LLM-based reviewers** can be over-thorough, suggest documentation where code is self-documenting, and sometimes provide positive feedback that shouldn't be taken as comprehensive validation.
 

--- a/skills/kworktree/SKILL.md
+++ b/skills/kworktree/SKILL.md
@@ -112,9 +112,27 @@ kinfra observability status  # Show service health and endpoints
 
 **Design (spec):** `kinfra spec <feature>` → work → `kinfra done <feature>`
 
-**Implementation (impl):** `kinfra impl <feature>/<milestone>` → sandbox + Claude session with `/kbuild` → `kinfra done <feature>-<milestone>`
+**Implementation (impl):** `kinfra impl <feature>/<milestone>` → fetches latest `origin/main`, branches from it → sandbox + Claude session with `/kbuild` → `kinfra done <feature>-<milestone>`
 
 **Without agent-deck:** `kinfra impl <feature>/<milestone> --no-session` → sandbox only, no Claude session
+
+### Manual Session Creation
+
+When `--no-session` is used and you need to create the agent-deck session manually, **always link it as a sub-session of the current session**:
+
+```bash
+# 1. Detect current session
+agent-deck session current
+# → Session: khealth (or whatever the parent is)
+
+# 2. Create session with --parent
+agent-deck add -t "<feature>/<milestone>" -c claude --parent <current-session-id> <worktree-path>
+
+# 3. Start it
+agent-deck session start <feature>/<milestone>
+```
+
+Never create standalone sessions from within an existing session — the parent-child relationship is how agent-deck tracks which sessions spawned which.
 
 ---
 

--- a/skills/kworktree/SKILL.md
+++ b/skills/kworktree/SKILL.md
@@ -2,7 +2,7 @@
 name: kworktree
 description: Worktree and sandbox management via kinfra CLI commands.
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # kworktree — Worktree & Sandbox Management
@@ -96,43 +96,95 @@ kinfra status
 # Shows: project, slot ID, status, ports
 ```
 
+### `kinfra sandbox start`
+
+Restart sandbox for an existing worktree (re-provisions secrets and files).
+
+### `kinfra sandbox rebuild`
+
+Rebuild sandbox with latest code changes. Re-provisions secrets/files AND rebuilds Docker images from source. **Use this after code changes** — `start` only restarts existing images.
+
 ### `kinfra observability up|down|status`
 
 Manage the shared observability stack.
-
-```bash
-kinfra observability up      # Start Jaeger + Grafana + Prometheus
-kinfra observability down    # Stop the stack
-kinfra observability status  # Show service health and endpoints
-```
 
 ---
 
 ## Workflows
 
-**Design (spec):** `kinfra spec <feature>` → work → `kinfra done <feature>`
+### Implementation (the main workflow)
 
-**Implementation (impl):** `kinfra impl <feature>/<milestone>` → fetches latest `origin/main`, branches from it → sandbox + Claude session with `/kbuild` → `kinfra done <feature>-<milestone>`
+Every `kinfra impl` MUST produce three things: worktree + sandbox + agent-deck child session.
 
-**Without agent-deck:** `kinfra impl <feature>/<milestone> --no-session` → sandbox only, no Claude session
+**Step 1: Create worktree**
+```bash
+kinfra impl <feature>/<milestone> --no-session
+```
 
-### Manual Session Creation
+**Step 2: Create agent-deck child session (MANDATORY)**
 
-When `--no-session` is used and you need to create the agent-deck session manually, **always link it as a sub-session of the current session**:
+This is NOT optional. After every `kinfra impl`, immediately create the session:
 
 ```bash
-# 1. Detect current session
+# Get current session name
 agent-deck session current
-# → Session: khealth (or whatever the parent is)
 
-# 2. Create session with --parent
-agent-deck add -t "<feature>/<milestone>" -c claude --parent <current-session-id> <worktree-path>
+# Create child session (substitute actual values)
+agent-deck add -t "<feature>/<milestone>" -c claude --parent <current-session-name> <worktree-path>
 
-# 3. Start it
+# Example:
+agent-deck add -t "health-advisor/M2" -c claude --parent khealth /Users/karl/Documents/dev/wellness-agent-impl-health-advisor-M2
+```
+
+The `--parent` flag links the child to the current session — this is how agent-deck tracks which sessions spawned which.
+
+**Step 3: Report to user**
+Tell the user the session is ready and how to start it:
+```
 agent-deck session start <feature>/<milestone>
 ```
 
-Never create standalone sessions from within an existing session — the parent-child relationship is how agent-deck tracks which sessions spawned which.
+### Design (spec)
+
+`kinfra spec <feature>` → work → `kinfra done <feature>`
+
+### Cleanup
+
+`kinfra done <feature>-<milestone>` — also removes the agent-deck session automatically.
+
+---
+
+## Sandbox Operations
+
+### After code changes: rebuild
+
+Source code is COPY'd into Docker images at build time. There is NO hot reload. After changing code, you MUST rebuild:
+
+```bash
+# From the worktree directory:
+kinfra sandbox rebuild
+# Re-provisions secrets/files, then runs docker compose up --build -d
+```
+
+Do NOT run raw `docker compose` commands. `kinfra sandbox rebuild` handles compose files, override files, env files, and secrets correctly.
+
+### Restarting without rebuild
+
+```bash
+kinfra sandbox start
+# Re-provisions secrets/files, restarts containers with existing images
+```
+
+### Discovering the sandbox
+
+Before any E2E or sandbox interaction, always discover the sandbox state:
+
+```bash
+kinfra status
+# Shows: slot ID, ports, whether sandbox is running
+```
+
+Port formula: `actual_port = base_port + slot_id`. The `.env.sandbox` file in the slot directory contains all port mappings as environment variables.
 
 ---
 
@@ -148,8 +200,6 @@ url = "http://localhost:8080/api/v1/health"
 # Check: kinfra status → API_PORT: 8081
 url = "http://localhost:8081/api/v1/health"
 ```
-
-Port formula: `actual_port = base_port + slot_id`. The `.env.sandbox` file in the slot directory contains all port mappings as environment variables.
 
 For OTEL configuration in sandbox services:
 - Exporter endpoint: `http://devops-ai-jaeger:4317` (container network)
@@ -182,8 +232,9 @@ Filter traces by namespace in Jaeger UI:
 | Sandbox fails to start | Check `docker compose logs` in the slot directory |
 | Health check timeout | Services may still be starting — check logs |
 | Dirty worktree on done | Commit or stash changes, or use `--force` |
-| Port conflict | kinfra auto-selects next available slot |
-| agent-deck not installed | Session skipped with warning, impl still works |
+| Port conflict | `kinfra done` the old worktree first, or kinfra auto-selects next slot |
+| Orphaned containers after done | `docker ps` to find them, `docker rm -f` to clean up |
+| Code changes not reflected | Run `kinfra sandbox rebuild` (not `start`) |
 
 ---
 

--- a/src/devops_ai/cli/done.py
+++ b/src/devops_ai/cli/done.py
@@ -124,8 +124,8 @@ def done_command(
             clean = stop_sandbox(slot)
             if not clean:
                 sandbox_warning = (
-                    "  Warning: compose down failed, "
-                    "force-removed orphaned containers"
+                    "  Warning: compose down failed; "
+                    "attempted fallback cleanup"
                 )
             remove_slot_dir(slot_dir)
         else:

--- a/src/devops_ai/cli/done.py
+++ b/src/devops_ai/cli/done.py
@@ -116,11 +116,17 @@ def done_command(
     registry = load_registry()
     slot = get_slot_for_worktree(registry, wt.path)
 
+    sandbox_warning = ""
     if slot is not None:
         # Sandbox cleanup: stop → remove slot dir → release
         slot_dir = Path(slot.slot_dir)
         if slot_dir.exists():
-            stop_sandbox(slot)
+            clean = stop_sandbox(slot)
+            if not clean:
+                sandbox_warning = (
+                    "  Warning: compose down failed, "
+                    "force-removed orphaned containers"
+                )
             remove_slot_dir(slot_dir)
         else:
             logger.warning(
@@ -138,4 +144,6 @@ def done_command(
     parts = [f"Removed worktree: {wt.feature} ({wt.path})"]
     if slot is not None:
         parts.append(f"  Released slot {slot.slot_id}")
+    if sandbox_warning:
+        parts.append(sandbox_warning)
     return 0, "\n".join(parts)

--- a/src/devops_ai/cli/main.py
+++ b/src/devops_ai/cli/main.py
@@ -6,7 +6,7 @@ from devops_ai.cli.done import done_command
 from devops_ai.cli.impl import impl_command
 from devops_ai.cli.init_cmd import init_command
 from devops_ai.cli.observability import _down_command, _status_command, _up_command
-from devops_ai.cli.sandbox_cmd import sandbox_start_command
+from devops_ai.cli.sandbox_cmd import sandbox_rebuild_command, sandbox_start_command
 from devops_ai.cli.spec import spec_command
 from devops_ai.cli.status import status_command
 from devops_ai.cli.worktrees import worktrees_command
@@ -141,6 +141,14 @@ def obs_status() -> None:
 def sandbox_start() -> None:
     """Start sandbox for an existing worktree (re-runs provisioning)."""
     code, msg = sandbox_start_command()
+    typer.echo(msg)
+    raise typer.Exit(code)
+
+
+@sandbox_app.command(name="rebuild")
+def sandbox_rebuild() -> None:
+    """Rebuild sandbox with latest code (re-provisions + docker build)."""
+    code, msg = sandbox_rebuild_command()
     typer.echo(msg)
     raise typer.Exit(code)
 

--- a/src/devops_ai/cli/sandbox_cmd.py
+++ b/src/devops_ai/cli/sandbox_cmd.py
@@ -1,4 +1,4 @@
-"""kinfra sandbox — start/stop sandbox for existing worktrees."""
+"""kinfra sandbox — start/stop/rebuild sandbox for existing worktrees."""
 
 from __future__ import annotations
 
@@ -46,14 +46,19 @@ def _find_main_repo_root(worktree_path: Path) -> Path | None:
     return None
 
 
-def sandbox_start_command(
+def _sandbox_up(
     worktree_path: Path | None = None,
+    *,
+    build: bool = False,
 ) -> tuple[int, str]:
-    """Start sandbox for an existing worktree. Returns (exit_code, message).
+    """Shared logic for sandbox start and rebuild.
 
     Re-runs provisioning (files + secrets) before starting containers.
+    If ``build`` is True, rebuilds images from source.
     """
     cwd = (worktree_path or Path.cwd()).resolve()
+    verb = "rebuilt" if build else "started"
+    retry_cmd = "kinfra sandbox rebuild" if build else "kinfra sandbox start"
 
     # Walk up to find the worktree root (registered path)
     wt_path = cwd
@@ -112,7 +117,7 @@ def sandbox_start_command(
         for err in all_errors:
             lines.append(f"  {err.message}")
             lines.append("")
-        lines.append("Fix the issues above and retry: kinfra sandbox start")
+        lines.append(f"Fix the issues above and retry: {retry_cmd}")
         return 1, "\n".join(lines)
 
     # Write secrets file
@@ -121,9 +126,9 @@ def sandbox_start_command(
 
     # Start sandbox
     try:
-        start_sandbox(config, slot_info, wt_path)
+        start_sandbox(config, slot_info, wt_path, build=build)
     except RuntimeError as e:
-        return 1, f"Sandbox failed to start: {e}"
+        return 1, f"Sandbox failed to {verb}: {e}"
 
     # Mark slot as running
     slot_info.status = "running"
@@ -134,7 +139,7 @@ def sandbox_start_command(
 
     # Report
     lines = [
-        f"Sandbox started for: {wt_path}",
+        f"Sandbox {verb} for: {wt_path}",
         f"  Slot: {slot_info.slot_id}",
     ]
 
@@ -157,3 +162,20 @@ def sandbox_start_command(
         )
 
     return 0, "\n".join(lines)
+
+
+def sandbox_start_command(
+    worktree_path: Path | None = None,
+) -> tuple[int, str]:
+    """Start sandbox for an existing worktree. Returns (exit_code, message)."""
+    return _sandbox_up(worktree_path, build=False)
+
+
+def sandbox_rebuild_command(
+    worktree_path: Path | None = None,
+) -> tuple[int, str]:
+    """Rebuild sandbox for an existing worktree. Returns (exit_code, message).
+
+    Like start, but rebuilds Docker images from source code.
+    """
+    return _sandbox_up(worktree_path, build=True)

--- a/src/devops_ai/sandbox.py
+++ b/src/devops_ai/sandbox.py
@@ -236,7 +236,7 @@ def _force_remove_containers(project_name: str) -> bool:
             capture_output=True, text=True,
         )
         container_ids = result.stdout.strip().split()
-        if not container_ids or container_ids == [""]:
+        if not container_ids:
             return False
 
         logger.warning(

--- a/src/devops_ai/sandbox.py
+++ b/src/devops_ai/sandbox.py
@@ -186,9 +186,12 @@ def start_sandbox(
     config: InfraConfig,
     slot: SlotInfo,
     worktree_path: Path,
+    *,
+    build: bool = False,
 ) -> None:
     """Start sandbox containers using worktree's compose file.
 
+    If ``build`` is True, passes ``--build`` to rebuild images from source.
     On failure, runs compose down to clean partial containers, then raises.
     """
     slot_dir = Path(slot.slot_dir)
@@ -196,7 +199,8 @@ def start_sandbox(
     override_file = slot_dir / "docker-compose.override.yml"
     env_files = _env_files_for_slot(slot_dir)
 
-    cmd = _compose_cmd(compose_file, override_file, env_files, ["up", "-d"])
+    action = ["up", "--build", "-d"] if build else ["up", "-d"]
+    cmd = _compose_cmd(compose_file, override_file, env_files, action)
     logger.info("Starting sandbox: %s", " ".join(cmd))
 
     try:
@@ -218,11 +222,42 @@ def start_sandbox(
         )
 
 
-def stop_sandbox(slot: SlotInfo) -> None:
+def _force_remove_containers(project_name: str) -> bool:
+    """Fall back to docker rm -f for containers matching project name.
+
+    Used when compose down fails but containers are still running.
+    Returns True if any containers were removed.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "-a", "--filter",
+             f"label=com.docker.compose.project={project_name}",
+             "--format", "{{.ID}}"],
+            capture_output=True, text=True,
+        )
+        container_ids = result.stdout.strip().split()
+        if not container_ids or container_ids == [""]:
+            return False
+
+        logger.warning(
+            "Force-removing %d orphaned containers for %s",
+            len(container_ids), project_name,
+        )
+        subprocess.run(
+            ["docker", "rm", "-f", *container_ids],
+            capture_output=True, text=True,
+        )
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def stop_sandbox(slot: SlotInfo) -> bool:
     """Stop sandbox containers using slot dir's compose copy.
 
     Uses the compose copy (not worktree) because the worktree might
-    already be removed. Errors are ignored (best-effort cleanup).
+    already be removed. Falls back to force-removing containers if
+    compose down fails. Returns True if cleanup succeeded.
     """
     slot_dir = Path(slot.slot_dir)
     compose_file = slot.compose_file_copy
@@ -233,9 +268,22 @@ def stop_sandbox(slot: SlotInfo) -> None:
     logger.info("Stopping sandbox: %s", " ".join(cmd))
 
     try:
-        subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(cmd, capture_output=True, text=True)
     except FileNotFoundError:
         logger.warning("Docker not found, cannot stop sandbox")
+        return False
+
+    if result.returncode != 0:
+        logger.warning(
+            "compose down failed (rc=%d): %s",
+            result.returncode, result.stderr.strip(),
+        )
+        # Fall back: force-remove containers by project label
+        project_name = f"{slot.project}-slot-{slot.slot_id}"
+        _force_remove_containers(project_name)
+        return False
+
+    return True
 
 
 def run_health_gate(config: InfraConfig, slot: SlotInfo) -> bool:

--- a/src/devops_ai/worktree.py
+++ b/src/devops_ai/worktree.py
@@ -78,6 +78,20 @@ def _run_git(
     )
 
 
+def _fetch_and_resolve_start_point(repo_root: Path) -> str | None:
+    """Fetch origin/main and return it as a start point, or None to use HEAD."""
+    _run_git(["fetch", "origin", "main"], cwd=repo_root, check=False)
+    # Verify origin/main exists (fetch may have failed — no remote, offline, etc.)
+    result = _run_git(
+        ["rev-parse", "--verify", "origin/main"],
+        cwd=repo_root,
+        check=False,
+    )
+    if result.returncode == 0:
+        return "origin/main"
+    return None
+
+
 def create_spec_worktree(
     repo_root: Path, prefix: str, feature: str
 ) -> Path:
@@ -86,10 +100,12 @@ def create_spec_worktree(
     wt_path = spec_worktree_path(repo_root, prefix, feature)
     branch = spec_branch_name(feature)
 
-    _run_git(
-        ["worktree", "add", "-b", branch, str(wt_path)],
-        cwd=repo_root,
-    )
+    start_point = _fetch_and_resolve_start_point(repo_root)
+    cmd = ["worktree", "add", "-b", branch, str(wt_path)]
+    if start_point:
+        cmd.append(start_point)
+
+    _run_git(cmd, cwd=repo_root)
 
     # Create design directory in the worktree
     design_dir = wt_path / "docs" / "designs" / feature
@@ -101,17 +117,19 @@ def create_spec_worktree(
 def create_impl_worktree(
     repo_root: Path, prefix: str, feature: str, milestone: str
 ) -> Path:
-    """Create an impl worktree."""
+    """Create an impl worktree based on latest origin/main."""
     validate_feature_name(feature)
     wt_path = impl_worktree_path(
         repo_root, prefix, feature, milestone
     )
     branch = impl_branch_name(feature, milestone)
 
-    _run_git(
-        ["worktree", "add", "-b", branch, str(wt_path)],
-        cwd=repo_root,
-    )
+    start_point = _fetch_and_resolve_start_point(repo_root)
+    cmd = ["worktree", "add", "-b", branch, str(wt_path)]
+    if start_point:
+        cmd.append(start_point)
+
+    _run_git(cmd, cwd=repo_root)
 
     return wt_path
 

--- a/tests/unit/test_sandbox_cmd.py
+++ b/tests/unit/test_sandbox_cmd.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-from devops_ai.cli.sandbox_cmd import sandbox_start_command
+from devops_ai.cli.sandbox_cmd import sandbox_rebuild_command, sandbox_start_command
 
 
 def _setup_registry(tmp_path: Path, worktree_path: str, slot_id: int = 1) -> Path:
@@ -38,6 +38,15 @@ class TestSandboxStartNotWorktree:
         registry_path = _setup_registry(tmp_path, "/some/other/path")
         with patch("devops_ai.cli.sandbox_cmd.REGISTRY_PATH", registry_path):
             code, msg = sandbox_start_command(worktree_path=tmp_path / "unknown")
+        assert code == 1
+        assert "not a kinfra worktree" in msg.lower() or "not allocated" in msg.lower()
+
+
+class TestSandboxRebuildNotWorktree:
+    def test_errors_when_no_slot_found(self, tmp_path: Path) -> None:
+        registry_path = _setup_registry(tmp_path, "/some/other/path")
+        with patch("devops_ai.cli.sandbox_cmd.REGISTRY_PATH", registry_path):
+            code, msg = sandbox_rebuild_command(worktree_path=tmp_path / "unknown")
         assert code == 1
         assert "not a kinfra worktree" in msg.lower() or "not allocated" in msg.lower()
 

--- a/tests/unit/test_sandbox_lifecycle.py
+++ b/tests/unit/test_sandbox_lifecycle.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from devops_ai.config import InfraConfig, ServicePort
 from devops_ai.registry import SlotInfo
 from devops_ai.sandbox import (
+    _force_remove_containers,
     run_health_gate,
     start_sandbox,
     stop_sandbox,
@@ -146,13 +147,84 @@ class TestStopSandbox:
             "devops_ai.sandbox.subprocess.run",
             return_value=mock_result,
         ) as mock_run:
-            stop_sandbox(slot)
+            result = stop_sandbox(slot)
 
+        assert result is True
         cmd = mock_run.call_args[0][0]
         assert "down" in cmd
         # Uses slot compose copy (not worktree)
         f_idx = cmd.index("-f")
         assert str(slot_compose) in cmd[f_idx + 1]
+
+    def test_returns_false_on_compose_down_failure(self, tmp_path: Path) -> None:
+        """compose down fails → falls back to force-remove, returns False."""
+        slot_dir = tmp_path / "slot"
+        slot_dir.mkdir()
+        env_file = slot_dir / ".env.sandbox"
+        env_file.write_text("COMPOSE_PROJECT_NAME=myproj-slot-1\n")
+
+        slot = _slot(slot_dir=str(slot_dir))
+
+        fail_result = MagicMock()
+        fail_result.returncode = 1
+        fail_result.stderr = "no such service"
+
+        with (
+            patch(
+                "devops_ai.sandbox.subprocess.run",
+                return_value=fail_result,
+            ),
+            patch(
+                "devops_ai.sandbox._force_remove_containers",
+            ) as mock_force,
+        ):
+            result = stop_sandbox(slot)
+
+        assert result is False
+        mock_force.assert_called_once_with("myproj-slot-1")
+
+    def test_returns_false_when_docker_missing(self) -> None:
+        """Docker not installed → returns False."""
+        slot = _slot()
+
+        with patch(
+            "devops_ai.sandbox.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            result = stop_sandbox(slot)
+
+        assert result is False
+
+
+class TestForceRemoveContainers:
+    def test_removes_matching_containers(self) -> None:
+        """Finds and removes containers by project label."""
+        ps_result = MagicMock()
+        ps_result.stdout = "abc123\ndef456\n"
+        rm_result = MagicMock()
+
+        with patch(
+            "devops_ai.sandbox.subprocess.run",
+            side_effect=[ps_result, rm_result],
+        ) as mock_run:
+            result = _force_remove_containers("myproj-slot-1")
+
+        assert result is True
+        rm_cmd = mock_run.call_args_list[1][0][0]
+        assert rm_cmd == ["docker", "rm", "-f", "abc123", "def456"]
+
+    def test_no_containers_found(self) -> None:
+        """No matching containers → returns False."""
+        ps_result = MagicMock()
+        ps_result.stdout = ""
+
+        with patch(
+            "devops_ai.sandbox.subprocess.run",
+            return_value=ps_result,
+        ):
+            result = _force_remove_containers("myproj-slot-1")
+
+        assert result is False
 
 
 class TestHealthGate:


### PR DESCRIPTION
## Summary

- **install.sh reconciliation guard**: Detects uncommitted skill changes and local-only skills before overwriting. Prevents silent loss of skill improvements made during agent sessions. Aborts with resolution instructions unless `--force`.
- **stop_sandbox fallback**: Checks `docker compose down` return code. On failure, falls back to `docker rm -f` on containers matching the project label. Reports warning to user via `kinfra done`.
- **`kinfra sandbox rebuild` command**: New command that re-provisions secrets/files AND rebuilds Docker images with `--build`. Eliminates the need for agents to fumble with raw docker compose commands after code changes.
- **kworktree skill update**: Agent-deck session creation is now a mandatory step after every `kinfra impl`, with the exact command template front-and-center.
- **kbuild skill update**: VALIDATION tasks now require sandbox discovery (`kinfra status`) as step 0 before E2E execution, with instructions to rebuild if code has changed.
- **Preserve existing improvements**: Commits previously-uncommitted kreview and kworktree skill edits, plus worktree fetch-before-branch fix.

## Test plan

- [x] 276 unit tests pass (5 new tests added)
- [x] ruff + mypy clean
- [x] install.sh guard tested: detects dirty skills, reports local-only skills, aborts without `--force`
- [x] `kinfra sandbox rebuild` registered and shows in `kinfra sandbox --help`
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)