### PR TITLE
security: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
       - name: Install dependencies
         run: uv sync --all-groups --all-extras
       - name: Quality + tests

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,8 +18,8 @@ jobs:
   codeql:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
         with:
           languages: python
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs to mitigate supply-chain attacks like the Megalodon incident (May 18, 2026), where 5,500 repos were compromised in 6 hours via tag mutation on `actions-cool/issues-helper`. SHA-pinning locks the exact commit used, making tag moves irrelevant.

## Changes

Every `uses:` reference in `.github/workflows/ci.yml` and `.github/workflows/security.yml` now uses a 40-character commit SHA with the original version tag preserved as an inline comment.

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-python` | v5 | `a26af69be951a213d495a4c3e4e4022e16d87065` |
| `astral-sh/setup-uv` | v4 | `38f3f104447c67c051c4a08e39b64a148898af3a` |
| `github/codeql-action` (init + analyze) | v3 | `03e4368ac7daa2bd82b3e85262f3bf87ee112f57` |

## Test plan

- [ ] Verify CI workflow still passes (no logic changes, only version strings)
- [ ] Verify security/CodeQL workflow still runs correctly
- [ ] Confirm all SHAs resolve to the expected tagged commits