### PR TITLE
Loop-first workflow: structural gates, verifier hardening, machine-checkable milestones, kloop

### DIFF
--- a/docs/designs/kdesign-kplan-improvements/INTENT.md
+++ b/docs/designs/kdesign-kplan-improvements/INTENT.md
@@ -1,0 +1,303 @@
+> **ARCHIVED (2026-06-11).** Investigated during the loop-quality-gates effort: every concern in this intent had already landed in kdesign/kplan v0.2.0 (JTBDs, human-action checkpoints, implementation-readiness, negative space). Kept for the provenance of the core observation — "every high-leverage improvement came from Karl intervening, not from the skills prompting it" — which motivated the verifier-first redesign (structural gates, kloop, machine-checkable milestone files).
+
+# Improving kdesign & kplan — JTBD Traceability, Human-Action Visibility, Implementation-Readiness
+
+**Date:** 2026-05-27
+**Status:** Proposal / Intent (pre-design)
+**Authors:** Karl + Lux
+**Provenance:** CashFlow Pro MVP — one continuous design→plan→build pass:
+- `/kdesign` session (produced `DESIGN.md`, `ARCHITECTURE.md`, 36 JTBDs, 5 milestones)
+- `/kplan` session (produced `OVERVIEW.md`, full `M1`, `M2–M5` sketches)
+- M1 implementation session (corrected two of the planning assumptions — see §5)
+
+---
+
+## 1. The core observation
+
+Across a full design→plan→build cycle for a non-trivial feature, **every
+high-leverage improvement to the output came from Karl intervening, not from the
+skills prompting it.** The skills produced competent first drafts; the value was added
+where Karl injected structure the skill didn't ask for.
+
+| What Karl had to inject | Effect | Skill that should have prompted it |
+|--------------------------|--------|-------------------------------------|
+| "I want a comprehensive set of JTBDs, all matched to a milestone" | Forced full user-story coverage; **surfaced a scenario that was missing entirely** (a watchlist account) | kdesign |
+| "tell me when I need to do something (like `/kinfra-onboard`) if it can't be automated" | Made human-only steps explicit instead of buried in prose | kplan |
+| "Are the E2E tests validating the JTBDs from the design doc?" | Exposed that validation touched stories as a *flow* but proved none of them per-story | kplan |
+| "Isn't there a ledger for past operations?" / "a read is a read" | Caught a command-query violation (a `GET` mutating state) and a temporal-model gap | kdesign (validation lens) |
+| "any unresolved questions before kplan?" | Surfaced two painful-to-change **data-representation** decisions (amount sign model, liquidity flag) | kdesign (closing pass) |
+
+Two of these (JTBDs, and the "validate the JTBDs" question) are the same idea seen
+from the design side and the plan side. They are the headline change.
+
+This document proposes concrete edits to `skills/kdesign/SKILL.md` and
+`skills/kplan/SKILL.md`, prioritized, each grounded in what actually happened and —
+where relevant — tempered by what the M1 build taught us.
+
+---
+
+## 2. kdesign changes
+
+### 2.1 JTBDs as a mandatory, first-class artifact  ⭐ (highest leverage)
+
+**Evidence.** The skill currently says to explore "user scenarios." That was vague
+enough that the first design had a thin "scenarios" section and moved on. Only when
+Karl asked for a *comprehensive, numbered, milestone-tagged* JTBD set did coverage
+become real — and the act of enumerating them surfaced a capability (a watchlist
+credit-card account) that nothing else in the design or the eventual E2E had captured.
+
+**Problem.** "Scenarios" is treated as illustrative color, not as a coverage contract.
+Nothing forces enumeration, IDs, or a mapping to milestones.
+
+**Proposed change.** Make a JTBD set a required output of kdesign:
+- Job-story form: *When ⟨situation⟩, I want to ⟨motivation⟩, so I can ⟨outcome⟩.*
+- Each story gets a stable ID (`J1`, `J2`, …) and is tagged to exactly one milestone
+  (the milestone where the job first becomes doable end-to-end).
+- The milestone structure cross-references the IDs both ways (a "Stories" column), so
+  the mapping is enforced from both sides.
+- Include "tool/agent as a client" stories where the system is API-first (e.g. "When I
+  hand Claude Code a screenshot, I want it to do everything the UI can via the API").
+
+**Right-sizing caveat (must be in the skill).** Scale the JTBD set to feature
+complexity. A 2-hour change does not need 35 job stories. The skill already has a
+"right-sized" principle; the JTBD requirement must inherit it, or it becomes ceremony.
+
+**Where it lands.** Add to "What This Produces"; add a "Jobs To Be Done" subsection
+under "What to Explore" (before Milestones); make the Milestones step require JTBD tags.
+
+---
+
+### 2.2 An implementation-readiness pass before finishing  ⭐ (the sleeper)
+
+**Evidence.** Karl's "any unresolved questions before kplan?" caught two decisions that
+were *not behavioral* and *not state-machine* — they were data-representation choices:
+- **Amount model:** signed amount vs. positive magnitude + direction-by-legs.
+- **Liquidity:** hardcode-by-type vs. a per-account `counts_as_liquid` flag.
+
+Both are cheap to decide on a whiteboard and expensive to change after schema + engine
+exist. The kdesign gap-hunting found none of them because all its lenses point at
+*behavior* (state transitions, error paths, concurrency).
+
+**Problem.** kdesign has no lens for "how is this entity *shaped* in storage and on the
+wire?" — the representation decisions that calcify the moment code is written.
+
+**Proposed change.** Add a closing **Implementation-readiness check** to kdesign: a
+short checklist run before declaring the design done. Candidate items:
+- **Units & money:** currency, decimal precision, integer-cents vs decimal.
+- **Sign/direction conventions:** signed values vs magnitude+direction.
+- **Identity:** id scheme; any synthetic/derived ids; uniqueness keys.
+- **Enums & nullability:** closed sets named; which fields are optional and why.
+- **Time:** date vs datetime; timezone ownership; is "now" injectable?
+- **Side-effects / purity:** which operations are pure reads? (see 2.3)
+
+Each item is a one-line decision or an explicit "deferred to milestone N (low risk)."
+
+**Where it lands.** New section after "Validation," before "Output." Frame it as the
+hand-off contract to kplan: "these are the choices kplan will otherwise invent in code."
+
+---
+
+### 2.3 A command-query / side-effect lens in the gap categories  (medium)
+
+**Evidence.** Karl caught that `GET /ledger` was mutating the detachment frontier ("a
+read is a read"). The fix reshaped the architecture (a scheduled sweep + write-path
+triggers; pure reads). The brief had even *invited* the smell ("no cron").
+
+**Problem.** kdesign's gap categories are: state-machine, error-handling, data-shape,
+integration, concurrency. None ask "where do side-effects live / are reads pure?"
+
+**Proposed change.** Add a gap category: **Side-effect / command-query gaps** — "Does a
+read mutate state? Does an operation have a side-effect its name doesn't imply? Where
+does each state change get triggered, and is that the same surface as the read?" This
+is general (CQS) and would have surfaced the frontier issue without Karl.
+
+**Where it lands.** "Validation → Gap categories to look for."
+
+---
+
+## 3. kplan changes
+
+### 3.1 Mandate JTBD ↔ milestone ↔ E2E traceability  ⭐ (highest leverage; enforcement half of 2.1)
+
+**Evidence.** "Are the E2E tests validating the JTBDs?" — honest answer at the time was
+*no*: the M1 validation exercised stories as a flow but asserted none per-story, and
+one story (watchlist) wasn't even in the scenario. We added a "Stories" column to the
+milestone table and a JTBD-coverage table to each VALIDATION task; the latter
+immediately exposed the missing assertion.
+
+**Problem.** kplan mandates *that* a VALIDATION task exists, but not that it proves the
+milestone's user stories. "Validated" can mean "the flow ran," not "every job this
+milestone owns is observably satisfied."
+
+**Proposed change.** Make story traceability structural:
+- The milestone table carries a **Stories** column (the JTBD IDs the milestone owns).
+- Every VALIDATION task carries a **JTBD coverage audit**: each owned JTBD → the
+  concrete assertion that proves it + the evidence captured. A milestone is not
+  validated until each owned JTBD has a passing, evidence-backed assertion.
+- A consistency check: every JTBD from the design appears in exactly one milestone's
+  Stories column, and every JTBD has ≥1 covering assertion.
+
+**⚠️ Tempered by M1 implementation — DO NOT conflate coverage with recipe count.**
+During the build, Karl pushed back twice on recipe granularity: first against one
+monolithic per-milestone recipe, then against over-correcting to one-recipe-per-JTBD.
+The settled model (now a CashFlow memory): **ke2e recipes are reusable,
+capability-scoped building blocks the scout composes across milestones** — each stands
+alone with minimal setup, covers a single capability, and is reusable in future
+milestones (e.g. `ledger/read-purity` is reused by any `GET`). Therefore:
+- The JTBD-coverage table is an **audit/mapping over assertions**, not a recipe-per-JTBD
+  structure. One reusable recipe may satisfy assertions for several JTBDs; one JTBD may
+  be proven by assertions spread across recipes.
+- kplan should describe recipes as capability blocks and explicitly warn against both
+  failure modes (one-giant-recipe and rigid-one-per-JTBD).
+
+**Where it lands.** "Architecture Alignment" (add story traceability) and "VALIDATION
+Tasks" (add the coverage-audit requirement + the capability-block framing).
+
+---
+
+### 3.2 Human-action callouts  ⭐ (workflow-critical)
+
+**Evidence.** The first plan buried `/kinfra-onboard` in prose as if automatic. Karl:
+"tell me when I need to do something … if it cannot be done automatically." We added a
+`👤 HUMAN ACTION` convention inline at the exact task step, plus a consolidated
+checklist in OVERVIEW.
+
+**Problem.** kbuild needs to know precisely when to stop and hand control to the human
+(interactive logins, infra onboarding, secret provisioning, PR review/merge). The skill
+never asks the planner to surface these.
+
+**Proposed change.**
+- Add an optional **Human action** field to the Task Structure template, used whenever a
+  step can't be automated, placed at the exact point it's needed.
+- Require a consolidated **Human-action checkpoints** table in OVERVIEW (when / action /
+  why-not-automatable).
+
+**⚠️ Tempered by M1 implementation — the infra story I wrote was wrong.** The plan told
+Karl to run `/kinfra-onboard` after the compose file lands, and to validate against a
+"kinfra sandbox." Reality (now a CashFlow memory):
+- **Onboarding is one-time `kinfra init`** (generates `.devops-ai/infra.toml`,
+  parameterizes compose, Justfile/pre-commit/CI). It is *not* a per-milestone step.
+- **A kinfra *sandbox* comes only from `kinfra impl <feature>/<milestone>`, which forks
+  a NEW worktree from `main`** — useless for a hand-made feature-branch worktree, and
+  Karl rejected the worktree gymnastics outright.
+- **Per-milestone E2E runs against the local `docker compose` stack in the current
+  worktree** (real HTTP at `localhost:PORT`, reset DB between aggregate-asserting
+  recipes).
+
+So the skill guidance must (a) distinguish one-time onboarding from per-milestone
+validation infra, and (b) default E2E to "the current worktree's compose stack," not a
+sandbox that forks main. This is a concrete gotcha worth encoding in both kplan's
+human-action guidance and the VALIDATION task's pre-flight.
+
+**Where it lands.** "Task Expansion → Task Structure" (new field), "Output Structure"
+(OVERVIEW must include the checklist), and a note in "VALIDATION Tasks" about the
+compose-vs-sandbox default.
+
+---
+
+### 3.3 Just-in-time planning depth as an explicit, named mode  (medium-high)
+
+**Evidence.** kplan reads as "expand all milestones into full tasks." We instead did
+**full M1 + sketches for M2–M5 + re-plan-before-build**, and it was the right call:
+M4/M5 detail would have been reworked once M1–M3 surfaced integration learnings (as
+indeed happened — see the two M1 corrections above). Karl explicitly endorsed and asked
+to confirm the "re-run kplan per milestone later" loop.
+
+**Problem.** The skill's default invites over-investment in far-milestone detail that is
+predictably reshaped by earlier milestones.
+
+**Proposed change.** Add a **Planning depth** subsection offering two modes, recommending
+the first for multi-milestone work:
+- **Just-in-time (recommended):** OVERVIEW (all milestones, deps, branch strategy) +
+  full tasks for the next milestone + lightweight sketches (goals, key tasks, risks) for
+  later ones, each marked "SKETCH — re-plan before build." Re-run kplan scoped to one
+  milestone before kbuild executes it, feeding the prior milestone's handoff.
+- **Full up-front:** every milestone fully expanded — for short or highly-stable plans.
+
+**Where it lands.** New subsection under "Task Expansion"; reference it from "Output
+Structure" (sketch files are legitimate milestone files).
+
+---
+
+### 3.4 Sharpen the consistency check for dependency *direction*  (medium)
+
+**Evidence.** I parked month-low/overdraft *computation* in M5 while M4 *rendered* it —
+a backwards dependency. The current consistency check ("dependency ordering is correct")
+didn't catch it; I only found it by manual scan.
+
+**Problem.** "Ordering correct" is about prerequisites, not about a later milestone's
+*output* being consumed earlier.
+
+**Proposed change.** Add a consistency-check bullet: **"No milestone consumes or renders
+an artifact that a later milestone produces."** When found, either move the producer
+earlier or split it.
+
+**Where it lands.** "Output Structure → Consistency Check."
+
+---
+
+## 4. Cross-cutting: close the build→design feedback loop
+
+The two M1 memories that corrected this plan (recipe granularity; compose-not-sandbox)
+are exactly the kind of learning that should flow back into the skills — yet today it
+only happens because Karl carries it between sessions. Worth considering (not
+necessarily now): a lightweight convention where a milestone handoff flags "skill
+assumption X was wrong" so the next kplan/kdesign run (or a periodic skill review) can
+absorb it. This document is a manual instance of that loop.
+
+---
+
+## 5. Prioritization
+
+| # | Change | Skill | Leverage | Notes |
+|---|--------|-------|----------|-------|
+| 2.1 | JTBDs as required artifact | kdesign | ⭐ High | Headline; pairs with 3.1 |
+| 3.1 | JTBD↔milestone↔E2E traceability | kplan | ⭐ High | Enforcement; respect capability-block nuance |
+| 3.2 | Human-action callouts | kplan | ⭐ High | Fix the compose-vs-sandbox framing too |
+| 2.2 | Implementation-readiness pass | kdesign | High | The sleeper — catches representation decisions |
+| 3.3 | Just-in-time planning depth | kplan | Med-High | Workflow; already validated in practice |
+| 3.4 | Dependency-direction check | kplan | Medium | Small, sharp |
+| 2.3 | Command-query / side-effect lens | kdesign | Medium | General CQS hygiene |
+
+**Recommended first cut:** 2.1 + 3.1 + 3.2 (with the two implementation corrections),
+then 2.2. The rest can follow.
+
+---
+
+## 6. Open questions for the design pass
+
+1. **JTBD home** — own section in kdesign output, or folded into DESIGN.md? (CashFlow put
+   them in DESIGN.md §9; worked well.)
+2. **Coverage-audit format** — a table in each VALIDATION task (what we did) vs a single
+   milestone-level matrix. Must stay decoupled from recipe count (3.1).
+3. **Implementation-readiness checklist** — fixed list vs. project-type-aware (Python vs
+   TS vs infra surface different representation traps).
+4. **Where the compose-vs-sandbox guidance belongs** — kplan only, or also a rule
+   (`e2e-testing.md`) since it's a cross-skill operational fact?
+5. **Feedback-loop mechanism (§4)** — in scope for this effort, or a separate one?
+
+---
+
+## 7. Concrete edit appendix (starting points, not final wording)
+
+**kdesign/SKILL.md**
+- *What This Produces:* add "4. **Jobs To Be Done** — numbered job stories, each tagged
+  to a milestone."
+- *What to Explore → new "Jobs To Be Done" subsection:* job-story form, IDs, milestone
+  tags, client-as-user stories, right-sizing caveat.
+- *Validation → Gap categories:* add "Side-effect / command-query gaps."
+- *New section "Implementation-readiness check"* (after Validation): the representation
+  checklist from 2.2.
+- *Milestones:* require each milestone to list the JTBD IDs it delivers.
+
+**kplan/SKILL.md**
+- *Architecture Alignment:* add story-traceability extraction (which JTBDs each milestone
+  owns).
+- *Task Expansion → Task Structure:* add optional `**Human action:**` field.
+- *New subsection "Planning depth"*: just-in-time vs full up-front (3.3).
+- *VALIDATION Tasks:* add the JTBD-coverage-audit requirement; add the "recipes are
+  reusable capability blocks (not one-giant, not one-per-JTBD)" framing; add the
+  "E2E against the current worktree's compose stack, not a main-forking sandbox"
+  pre-flight note.
+- *Output Structure:* OVERVIEW must include a Human-action-checkpoints table; sketch
+  milestone files are legitimate; add the dependency-direction consistency bullet (3.4).

--- a/rules/structural-gates.md
+++ b/rules/structural-gates.md
@@ -1,0 +1,42 @@
+# Structural Gates
+
+Code structure is a gated quality dimension, exactly like lint and tests. Spaghetti passes
+every functional gate — it type-checks, each copy has passing tests, the feature works. These
+gates exist because the agents writing code have no other signal that structure is degrading,
+and a human reading classes is not a scalable sensor.
+
+## The gate
+
+Every project carries `tests/architecture/test_invariants.py`, run as part of the quality
+checks (in `make check`, so pre-commit and CI both enforce it). It encodes the
+machine-checkable half of the project's architecture:
+
+- **File budgets** — no source file beyond the configured line cap (default 400)
+- **Module shape** — caps on classes/dataclasses per module (a module quietly collecting
+  result types is how god-files start)
+- **Layering contracts** — which packages may import which ("domain never imports api")
+- **Pattern uniqueness** — one mechanism per job ("no `*Result` dataclass outside
+  `results/`", "exactly one router base")
+- **Ratchets** — frozen allowlists for violations that pre-date the gate
+
+A starter lives at `templates/test_invariants.py`. Project-specific thresholds go in
+`.devops-ai/project.md` under a **Structure** section; otherwise defaults apply.
+
+## The non-negotiables
+
+- **A structural gate failure is fixed by changing the code — never by editing the
+  threshold, the contract, or the allowlist.** Widening anything requires Karl's explicit
+  sign-off in the conversation, recorded in the handoff.
+- **Ratchets only shrink.** The allowlist freezes the violations that existed when the gate
+  was introduced; new code meets the bar immediately. When a legacy file comes into
+  compliance, its entry is removed (the test enforces this) so it can't regress.
+- **Three sign-off requests against the same contract is a design signal, not a third
+  exception.** The contract is probably wrong — write an ACP (see kbuild) so it gets
+  decided, not routed around.
+
+## Where the contracts come from
+
+From the architecture: each enforceable decision in ARCHITECTURE.md should name its check
+here. A decision that can't be expressed as a machine check is enforced as a named lens in
+kbuild's structural review instead — but that's an explicit choice, recorded in the doc,
+not a default.

--- a/rules/structural-gates.md
+++ b/rules/structural-gates.md
@@ -17,6 +17,9 @@ machine-checkable half of the project's architecture:
 - **Layering contracts** — which packages may import which ("domain never imports api")
 - **Pattern uniqueness** — one mechanism per job ("no `*Result` dataclass outside
   `results/`", "exactly one router base")
+- **Test honesty** — patch-density caps and no first-party patching (per the `tdd` rule:
+  testing theatre is a structure problem; a mock-welded suite resists every refactor the
+  other gates demand)
 - **Ratchets** — frozen allowlists for violations that pre-date the gate
 
 A starter lives at `templates/test_invariants.py`. Project-specific thresholds go in

--- a/rules/structural-gates.md
+++ b/rules/structural-gates.md
@@ -7,8 +7,11 @@ and a human reading classes is not a scalable sensor.
 
 ## The gate
 
-Every project carries `tests/architecture/test_invariants.py`, run as part of the quality
-checks (in `make check`, so pre-commit and CI both enforce it). It encodes the
+Every project carries a structural-invariants gate, run as part of the quality checks
+(in `make check`, so pre-commit and CI both enforce it). For Python projects that's
+`tests/architecture/test_invariants.py` (starter template below); non-Python projects
+encode the same contracts with their stack's tooling (e.g. dependency-cruiser or ts-arch
+for TypeScript layering, ESLint rules for pattern caps). The gate encodes the
 machine-checkable half of the project's architecture:
 
 - **File budgets** — no source file beyond the configured line cap (default 400)
@@ -22,8 +25,9 @@ machine-checkable half of the project's architecture:
   other gates demand)
 - **Ratchets** — frozen allowlists for violations that pre-date the gate
 
-A starter lives at `templates/test_invariants.py`. Project-specific thresholds go in
-`.devops-ai/project.md` under a **Structure** section; otherwise defaults apply.
+A starter lives at `templates/test_invariants.py` (devops-ai). Thresholds and contracts
+are configured in the copied file's own Configuration block — once copied into
+`tests/architecture/`, it is project-owned, versioned with the code it constrains.
 
 ## The non-negotiables
 

--- a/rules/tdd.md
+++ b/rules/tdd.md
@@ -14,6 +14,14 @@ Write just enough code to make tests pass. Follow existing patterns in the codeb
 
 Clean up code, extract patterns, add type hints. Run tests after each change to confirm nothing breaks. Run quality checks if configured.
 
+## What a unit is: behavior at the process boundary
+
+A unit is a behavior, not a class. Write tests through the smallest *stable* public surface — a service function, an engine entry point, the in-process API (an ASGI test client makes no network calls) — and let everything inside the process run real. Speed comes from avoiding I/O, not from avoiding your own code: calling your own functions costs nanoseconds, and the <100ms budget survives running the entire domain layer.
+
+Replace only what is slow or non-deterministic — network, database, subprocess, LLM calls, the clock — and prefer **hand-written fakes implementing a port** (in-memory repository, fixed clock, canned responses) over `patch()`. A patch is welded to an import path and a call signature, so it breaks when structure changes even though behavior didn't; a fake survives any refactor that preserves the contract. Patching first-party code is a coupling smell the structural gates count (see the `structural-gates` rule). Integration tests then have one precise job: prove each fake honest by running the same contract suite against the real adapter.
+
+Assert observable outcomes, not call choreography. "The service called `repo.save(x)`" fails on restructuring with behavior intact — a corrupted signal that teaches the build loop to distrust red. Assert an interaction only when the interaction *is* the contract ("exactly one notification sent"). The bar for every test: **it fails if and only if behavior the design cares about changed.**
+
 ## Why TDD matters
 
 Tests written after implementation tend to test what the code does, not what it should do. Writing tests first forces you to think about behavior and edge cases before committing to an implementation approach.

--- a/rules/testing-taxonomy.md
+++ b/rules/testing-taxonomy.md
@@ -6,13 +6,13 @@ Tests are classified by what they exercise and what they need to run.
 
 | Type | Directory | Speed | Dependencies | Runs in |
 |------|-----------|-------|-------------|---------|
-| Unit | tests/unit/ | <100ms each | None (mocks only) | Pre-commit, CI |
+| Unit | tests/unit/ | <100ms each | None (no I/O; fakes at the seams) | Pre-commit, CI |
 | Integration | tests/integration/ | <5s each | Real services | CI |
 | E2E | tests/e2e/ | <30s each | Full running system | Milestone validation |
 
 ## Unit tests
 
-Unit tests exercise individual functions and classes in isolation. They must have:
+Unit tests exercise behaviors through public surfaces, with the in-process stack running real. "Unit" is a speed-and-determinism contract (no I/O), not a one-class isolation rule — the `tdd` rule defines where the fake/real line lives. They must have:
 
 - No network calls (no `socket.connect`, no HTTP requests)
 - No subprocess spawning (no `subprocess.run` unless mocked)

--- a/skills/kbuild/SKILL.md
+++ b/skills/kbuild/SKILL.md
@@ -2,7 +2,7 @@
 name: kbuild
 description: Execute tasks (TDD) and orchestrate milestones from implementation plans.
 metadata:
-  version: "0.2.0"
+  version: "0.3.0"
 ---
 
 # Build Command
@@ -14,7 +14,8 @@ tasks with verification between them.
 
 - **Single task:** `/kbuild impl: <milestone-file> task: <task-id>`
 - **Full milestone:** `/kbuild impl: <milestone-file>` — run tasks in order. A task isn't done
-  until its tests pass, quality gates pass, the change is committed, and the handoff reflects it.
+  until it *converges* (see "A task converges" below): all gates green, structural review clean,
+  the change committed, and the handoff reflects it.
   Resume a partial milestone by reading the handoff for the first incomplete task.
 
 ## Context
@@ -42,6 +43,12 @@ If something contradicts the task's assumptions (files absent, patterns missing,
 changed), that's signal — verify with a second angle before proceeding, and report it rather than
 coding around a guess.
 
+Part of that context is **prior art**: before building a capability, name the existing mechanism
+you're extending — or state in the handoff that you searched and nothing does this job. The
+default is reuse; a new mechanism needs a reason. Agents writing rather than reading is how a
+seven-milestone codebase ends up doing one thing three ways, and no functional gate catches it —
+the claim is checkable, and the milestone structure pass checks it.
+
 Implementation plans carry **code samples that show structure and wiring, not finished behavior.**
 Read them for the pattern, then implement the real thing against the real code. Transcribing a
 sample verbatim is not implementing.
@@ -64,9 +71,47 @@ sample verbatim is not implementing.
 
 ## Implementation (CODING)
 
-TDD per the `tdd` rule; quality gates per the `quality-gates` rule. If infrastructure is
-configured, also run an integration smoke test — start the system, exercise the changed flow,
-read the logs — because passing unit tests on an unstarted system proves less than it looks.
+TDD per the `tdd` rule; quality gates per the `quality-gates` rule; structural invariants per
+the `structural-gates` rule. If infrastructure is configured, also run an integration smoke
+test — start the system, exercise the changed flow, read the logs — because passing unit tests
+on an unstarted system proves less than it looks.
+
+## A task converges; it doesn't just finish
+
+Run the task as a loop, as many times as it takes:
+
+1. **Gates** — tests, quality checks, structural invariants. Red → fix the code, rerun. A gate
+   is never fixed by editing the gate.
+2. **Structural review** — when gates are green, have a fresh-context subagent review the task's
+   diff with two lenses: *conformance* (does this violate boundaries the architecture doc
+   states?) and *consolidation* (does it duplicate a mechanism that exists, or would a reviewer
+   ask for it to be smaller, flatter, or merged with something nearby?). Fresh context is the
+   point — the hands that wrote the code can't grade its shape.
+3. **Converge** — confirmed findings get fixed via TDD, then back to step 1. Triage critically
+   (a reviewer can be wrong; trace before you act). A clean review closes the loop.
+
+Three cycles without convergence means the disagreement is real — stop and surface it to Karl
+rather than grinding. And if what you keep fighting is the architecture itself, that's an ACP
+(next section), not a fourth cycle.
+
+## When the architecture is the problem: propose, don't route around
+
+Sometimes the friction is real: a contract you keep needing exceptions to, a scenario the design
+genuinely doesn't fit. You are empowered — expected — to propose an architecture evolution. You
+are not empowered to make one silently.
+
+Write an **ACP** (`templates/acp.md` → `docs/designs/<feature>/acp/ACP-NNN.md`): the friction
+evidence, the design-level diagnosis, the proposed change, the **enforcement delta** (which
+contract changes — no delta means it's a refactor or a workaround, not an evolution), and the
+migration cost priced into a named milestone. Then keep implementing the task under the
+*current* architecture — pause only if genuinely blocked. The evolution, if approved, lands as
+its own task with its own diff; never bundled into the feature's.
+
+A fresh-context **critique agent** reviews the ACP adversarially before it reaches Karl: is this
+the design's problem or this task's inconvenience? does it create a second way of doing
+something that already has a way? does the enforcement delta actually close the loop? is the
+migration priced or hand-waved? Refuted → log it in the handoff and proceed under the current
+design. Endorsed → it goes to Karl as a one-screen decision.
 
 ## Handoff (every task)
 
@@ -99,6 +144,16 @@ corruption in load-bearing code earns your own trace before you act), and fix wh
 Clearing this bar *before* the PR is the point — it catches the bug class line-level review won't,
 and pre-empts the review rounds that would otherwise find the cheaper half of it.
 
+## The structure pass at milestone close
+
+Before VALIDATION, review the milestone's whole diff for what no single task could see: a job
+now done in two-plus places that should be one, a file that grew past its budget through small
+legitimate additions, a pattern that drifted from its siblings, a prior-art claim that didn't
+hold. A fresh-context subagent over `git diff <main>...HEAD` with the consolidation lens is
+well-suited. The top findings become a fix-now task inside this milestone, gated like any
+other — consolidation at the milestone that created the duplicate is one extraction task;
+discovered five milestones later, it's archaeology.
+
 ## Reconcile the architecture at milestone close
 
 When a milestone's tasks are done, the design/architecture docs are the spec the *next* `/kplan`
@@ -107,13 +162,22 @@ stale doc. This is the loop's most common slow failure, which is why it's a step
 
 Diff what you built against the `design:`/`architecture:` docs and find the **design-level**
 deltas — changes to the data model, state model, a contract/wire shape, an enum, an invariant, an
-API surface (not implementation detail). For each: the tested-and-validated code is the source of
-truth, so amend the doc to match, surgically. Resolve any internal contradiction in the docs and
-mark which representation is normative so it can't re-drift. If a decision is genuinely *open*
-(not merely undocumented), surface it rather than inventing a spec.
+API surface (not implementation detail). For each delta, ask: did it come through an approved
+ACP?
+
+- **Intentional** (ACP-backed) → amend the doc to match, surgically.
+- **Unintentional** (no ACP) → that's drift; editing the doc to match would legalize it.
+  Collect these into a **bless-or-fix list** for Karl: for each, he either blesses it (the doc
+  is amended, and the enforcement contract updated if one should have caught it) or it becomes
+  a fix task before the milestone closes.
+
+Resolve any internal contradiction in the docs and mark which representation is normative so it
+can't re-drift. If a decision is genuinely *open* (not merely undocumented), surface it rather
+than inventing a spec.
 
 Report what you reconciled (or "no architectural deltas"). A milestone that changed a contract but
-left the architecture untouched isn't finished.
+left the architecture untouched isn't finished — and neither is one whose drift list is silently
+self-approved.
 
 ## Milestone completion report
 
@@ -148,9 +212,17 @@ report untruthful, which is worse than a thin E2E section.
 | Finding | Severity | KEEP/SKIP | Action |
 |---------|----------|-----------|--------|
 
-### Architecture Reconciliation  (design-level deltas folded back into the docs)
-| Delta (reality vs. doc) | Doc amended |
-|-------------------------|-------------|
+### Structure pass  (consolidation findings and what was fixed)
+| Finding | Fixed in task / deferred (why) |
+|---------|--------------------------------|
+
+### ACPs raised this milestone
+| ACP | Verdict (critique) | Decision (Karl) |
+|-----|--------------------|-----------------|
+
+### Architecture Reconciliation  (design-level deltas)
+| Delta (reality vs. doc) | Via ACP? | Blessed / Fixed | Doc amended |
+|-------------------------|----------|-----------------|-------------|
 
 ### Failed Tests (not due to this work)
 | Test | Failure | Status |

--- a/skills/kbuild/SKILL.md
+++ b/skills/kbuild/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: kbuild
-description: Execute tasks (TDD) and orchestrate milestones from implementation plans.
+description: Execute tasks (TDD) and orchestrate milestones from implementation plans. Attended fallback — kloop is the autonomous path.
 metadata:
   version: "0.3.0"
+  status: frozen
 ---
 
 # Build Command
+
+> **Frozen (2026-06).** kbuild is the attended fallback; autonomous execution runs
+> through `kloop` (one task per fresh context, verifier-enforced). No further
+> investment in this file — what a build run teaches goes into the gates
+> (`templates/test_invariants.py`), the Stop hook, or kloop, never into prose here.
+> If kloop proves out on real milestones, kbuild gets deleted.
 
 Execute implementation-plan tasks with TDD, or orchestrate a whole milestone by sequencing
 tasks with verification between them.

--- a/skills/kdesign/SKILL.md
+++ b/skills/kdesign/SKILL.md
@@ -2,7 +2,7 @@
 name: kdesign
 description: Design and validate features through collaborative exploration. Produces DESIGN.md, ARCHITECTURE.md, JTBDs, and a milestone structure.
 metadata:
-  version: "0.2.0"
+  version: "0.3.0"
 ---
 
 # Design Command
@@ -16,7 +16,8 @@ a single conversation that replaces separate design, validation, and milestone-s
 2. **Jobs To Be Done** — numbered job stories (J1, J2, …), each tagged to the milestone where the
    job first becomes doable end-to-end. Lives as a section in DESIGN.md.
 3. **ARCHITECTURE.md** — the how: components, data flow, state, errors, interface signatures,
-   integration points.
+   integration points, and an **Enforcement** section mapping each structural decision to the
+   check that holds it.
 4. **Milestone structure** — vertical slices ready for planning, each listing the JTBDs it delivers.
 
 ```
@@ -90,7 +91,23 @@ a one-line decision or an explicit "deferred to milestone N (low risk)":
 
 This is the hand-off contract to kplan: these are the choices kplan will otherwise invent in code.
 
-## Milestones
+## Enforcement — every structural decision names its check
+
+Prose doesn't constrain the agents that will build this; gates do (the `structural-gates` rule).
+So ARCHITECTURE.md closes with an **Enforcement** table: each decision that constrains code
+structure, mapped to how it's held.
+
+| Decision | Enforced by |
+|----------|-------------|
+| Domain stays transport-free | invariant: `domain/` never imports `api/` or `fastapi` |
+| Result types live in one module | invariant: no `*Result` class outside `results.py` |
+| Reads are pure | review-lens: named in kbuild's structural review |
+
+Three kinds of entry: an **invariant** (machine-checked, lands in `tests/architecture/` — kplan
+turns these into M1's harness task), a **review-lens** (a named lens for kbuild's structural
+review, when no machine check can express it), or an explicit **unenforced** (a recorded
+acceptance, never a default). A decision that can't name its check is usually too vague to
+survive contact with implementation — sharpening it here is design work, not bureaucracy.
 
 Propose a vertical milestone structure (the `vertical-slicing` rule has the principles): each slice
 E2E-testable, building on the last, delivering user-visible value, and **listing the JTBD IDs it

--- a/skills/kdesign/SKILL.md
+++ b/skills/kdesign/SKILL.md
@@ -109,6 +109,8 @@ review, when no machine check can express it), or an explicit **unenforced** (a 
 acceptance, never a default). A decision that can't name its check is usually too vague to
 survive contact with implementation — sharpening it here is design work, not bureaucracy.
 
+## Milestones
+
 Propose a vertical milestone structure (the `vertical-slicing` rule has the principles): each slice
 E2E-testable, building on the last, delivering user-visible value, and **listing the JTBD IDs it
 delivers**. Milestone 1 is the smallest thing that proves the architecture works end-to-end —

--- a/skills/kloop/SKILL.md
+++ b/skills/kloop/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: kloop
+description: Execute one milestone task per fresh context — the loop body for autonomous runs. Verification is the gate; this file only sequences.
+metadata:
+  version: "0.1.0"
+---
+
+# kloop — the loop body
+
+One invocation = one task. The enforcement lives in the verifier (`make check`,
+the task's Verify command, the blocking Stop hook) — deliberately not in this file.
+
+```
+/kloop [milestone file]
+```
+
+## The loop body
+
+1. Read the milestone file (the argument, or the file with unchecked tasks under
+   the configured design path). Read the HANDOFF file next to it.
+2. Take the **first open task** (`## [ ] Task N.M`). None left → report the
+   milestone state (all `[x]`, or `[!]` blockers awaiting Karl) and stop.
+3. Search for prior art before writing anything new — extend the existing mechanism
+   or say in the handoff why you couldn't.
+4. Do the task as written (STRUCTURE and VALIDATION tasks carry their own
+   instructions). For code: TDD — failing tests first, then make the task's
+   **Verify** command and `make check` both exit 0. Never weaken a test, a gate,
+   or a threshold to get green.
+5. Flip the checkbox to `[x]` and append one evidence line under the heading:
+   the Verify command and its result tail.
+6. Add to the handoff only what the next task needs (gotchas, not status). Commit:
+   conventional message naming the task ID.
+7. Stop. The next task gets a fresh context.
+
+## Escalate instead of grinding
+
+Escalating flips the checkbox to `[!]` (blocked — a human decides) with a one-line
+reason under the heading, so the loop moves on instead of re-grinding it:
+
+- **The design fights the task** (third workaround against the same contract,
+  pattern that doesn't fit) → write an ACP (`templates/acp.md`), mark `[!]`, stop.
+- **A gate or Verify command looks wrong** → mark `[!]` with why. Editing
+  thresholds, contracts, or ratchets is Karl's call (`structural-gates` rule).
+- **Three failed attempts on one task** → mark `[!]`, record what was tried and
+  why it failed, stop.
+
+## Driving the loop
+
+The milestone file is the goal state; "done" is checkboxes plus a green gate —
+never the agent's claim.
+
+- **Shell loop (true fresh context per task, Ralph-style):** the file itself is
+  the loop condition — it terminates when every task is `[x]` or `[!]`:
+
+  ```sh
+  M=docs/designs/<feature>/implementation/M2_x.md
+  while grep -q '## \[ \]' "$M"; do
+    claude -p "/kloop $M" --permission-mode acceptEdits
+  done
+  ```
+- **Goal mode (one session, evaluator-checked):**
+  `/goal every task in docs/designs/<feature>/implementation/M2_x.md is checked [x] and make check exits 0`
+  — fine for a few tasks; for long milestones prefer the shell loop (compaction
+  degrades long sessions — state must live in the milestone file and git, not context).
+- The kinfra-generated Stop hook blocks any turn from ending while `make check`
+  is red, in both modes.

--- a/skills/kplan/SKILL.md
+++ b/skills/kplan/SKILL.md
@@ -2,7 +2,7 @@
 name: kplan
 description: Expand milestones into implementable tasks with architecture alignment, JTBD traceability, TDD requirements, and E2E validation.
 metadata:
-  version: "0.2.0"
+  version: "0.3.0"
 ---
 
 # Implementation Planning Command
@@ -36,6 +36,11 @@ either the architecture needs updating or the task is wrong.
 
 **Also extract the JTBD → milestone mapping** from the design. Each milestone owns a set of job
 stories (the IDs kdesign tagged). That ownership becomes a coverage contract, enforced below.
+
+**And extract the Enforcement table** from ARCHITECTURE.md — the invariant entries become M1's
+gate-harness task, and the review-lens entries ride along in each milestone's STRUCTURE task
+(both below). If the architecture has no Enforcement table, that's a kdesign gap: surface it
+before planning, don't invent contracts.
 
 ## A plan is graded on the negative space too, not just the jobs
 
@@ -110,6 +115,21 @@ One such step is frequently mis-described, so state it correctly:
   `localhost:PORT`, DB reset between aggregate-asserting recipes) — *not* a `kinfra impl` sandbox,
   which forks a new worktree from `main` and is the wrong tool for a hand-made feature branch.
 
+## Structural gates in the plan
+
+Two structural requirements, mirror-images of the VALIDATION rule below:
+
+- **M1 carries the gate-harness task:** copy `templates/test_invariants.py` (devops-ai) into
+  `tests/architecture/`, port the ARCHITECTURE.md Enforcement table into contracts, freeze
+  ratchets for pre-existing violations, and wire the directory into the project's check command
+  so pre-commit and CI run it. The gate exists *before* the code it must constrain — it is not
+  a retrofit step.
+- **Every milestone's task list ends STRUCTURE, then VALIDATION.** The STRUCTURE task is
+  kbuild's milestone-close structure pass (whole-diff consolidation review, findings fixed
+  in-milestone) made visible in the plan so it can't be skimmed past. List the Enforcement
+  table's review-lens entries in the task description — they are the lenses the reviewing
+  subagent must carry.
+
 ## VALIDATION tasks
 
 Every milestone ends with a VALIDATION task — a structural requirement, because "unit tests pass"
@@ -167,8 +187,10 @@ The milestone table carries a **Stories** column (the JTBD IDs each milestone ow
 **Consistency check before saving.** Every major design decision appears in at least one task;
 every architectural pattern has implementing tasks; no task uses a ruled-out approach; dependency
 ordering is correct; **every JTBD appears in exactly one milestone's Stories column with ≥1
-covering assertion**; and **no milestone consumes or renders an artifact a later milestone
-produces** (a backward dependency — move the producer earlier or split it).
+covering assertion**; **every invariant in the Enforcement table lands in M1's gate-harness
+task and every milestone ends STRUCTURE → VALIDATION**; and **no milestone consumes or renders
+an artifact a later milestone produces** (a backward dependency — move the producer earlier or
+split it).
 
 ## Integration
 

--- a/skills/kplan/SKILL.md
+++ b/skills/kplan/SKILL.md
@@ -2,7 +2,7 @@
 name: kplan
 description: Expand milestones into implementable tasks with architecture alignment, JTBD traceability, TDD requirements, and E2E validation.
 metadata:
-  version: "0.3.0"
+  version: "0.4.0"
 ---
 
 # Implementation Planning Command
@@ -85,11 +85,12 @@ the symbol exists in cache before starting download"), **tests specified** (not 
 "follow `UserService.create()`"). Split anything over ~4 hours.
 
 ```markdown
-## Task N.M: [Title]
+## [ ] Task N.M: [Title]
 
 **File(s):** [specific files to create/modify]
-**Type:** CODING | RESEARCH | MIXED | VALIDATION
+**Type:** CODING | RESEARCH | MIXED | STRUCTURE | VALIDATION
 **Estimated time:** [1–4 hours]
+**Verify:** [the command that proves this task — exits 0 only if the behavior works, e.g. `uv run pytest tests/unit/test_user.py -q`]
 **Human action:** [only if a step can't be automated — see below; omit otherwise]
 
 **Description:** [what it accomplishes — specific about behavior]
@@ -101,6 +102,14 @@ the symbol exists in cache before starting download"), **tests specified** (not 
 For tasks spanning multiple categories (persistence, wiring, state machines, …), identify each
 category's failure modes and add matching integration tests. The `kplan-categories.md` reference has
 the full taxonomy — load it when analyzing task types.
+
+**The milestone file is goal state, not prose.** The loop that executes it (kloop) and a `/goal`
+evaluator treat it as the completion contract: tasks are worked first-unchecked-first, and a
+checkbox flips to `[x]` only when the task's **Verify** command exits 0 — evidence, not the
+implementer's claim. So write Verify to actually discriminate: the test selector that fails if
+this task's behavior is wrong (`make check` runs on every task regardless — don't restate it).
+A task whose done-condition can't be a command gets the closest runnable proxy plus a named
+review-lens in the STRUCTURE task — never "done when it looks done."
 
 **Human-action callouts.** kbuild needs to know exactly when to stop and hand control to a human —
 interactive logins, secret provisioning, PR review/merge, one-time infra setup. Mark those at the
@@ -119,11 +128,13 @@ One such step is frequently mis-described, so state it correctly:
 
 Two structural requirements, mirror-images of the VALIDATION rule below:
 
-- **M1 carries the gate-harness task:** copy `templates/test_invariants.py` (devops-ai) into
-  `tests/architecture/`, port the ARCHITECTURE.md Enforcement table into contracts, freeze
-  ratchets for pre-existing violations, and wire the directory into the project's check command
-  so pre-commit and CI run it. The gate exists *before* the code it must constrain — it is not
-  a retrofit step.
+- **M1 carries the gate-harness task:** copy `templates/test_invariants.py` from the devops-ai
+  repo (locate it by resolving the skill symlink: `readlink ~/.claude/skills/kplan` → its parent
+  repo) into `tests/architecture/`, port the ARCHITECTURE.md Enforcement table into contracts,
+  and freeze ratchets for pre-existing violations. kinfra-generated Makefiles already run
+  `tests/architecture/` inside `make check` (a `kinfra init` re-run refreshes older ones), so
+  pre-commit, CI, and the Stop hook all enforce it with no extra wiring. The gate exists
+  *before* the code it must constrain — it is not a retrofit step.
 - **Every milestone's task list ends STRUCTURE, then VALIDATION.** The STRUCTURE task is
   kbuild's milestone-close structure pass (whole-diff consolidation review, findings fixed
   in-milestone) made visible in the plan so it can't be skimmed past. List the Enforcement
@@ -186,15 +197,17 @@ The milestone table carries a **Stories** column (the JTBD IDs each milestone ow
 
 **Consistency check before saving.** Every major design decision appears in at least one task;
 every architectural pattern has implementing tasks; no task uses a ruled-out approach; dependency
-ordering is correct; **every JTBD appears in exactly one milestone's Stories column with ≥1
-covering assertion**; **every invariant in the Enforcement table lands in M1's gate-harness
-task and every milestone ends STRUCTURE → VALIDATION**; and **no milestone consumes or renders
-an artifact a later milestone produces** (a backward dependency — move the producer earlier or
-split it).
+ordering is correct; **every task heading carries an unchecked `[ ]` and a Verify command that
+discriminates** (a Verify that passes before the task is implemented proves nothing); **every
+JTBD appears in exactly one milestone's Stories column with ≥1 covering assertion**; **every
+invariant in the Enforcement table lands in M1's gate-harness task and every milestone ends
+STRUCTURE → VALIDATION**; and **no milestone consumes or renders an artifact a later milestone
+produces** (a backward dependency — move the producer earlier or split it).
 
 ## Integration
 
-kplan sits between `/kdesign` (produces the design + JTBDs) and `/kbuild` (executes the tasks). The
-milestone files are the interface contract between planning and execution. When a build surfaces a
-wrong planning assumption, that belongs in the handoff so the next kplan run absorbs it.
+kplan sits between `/kdesign` (produces the design + JTBDs) and execution — `/kloop` (the
+autonomous loop, one task per fresh context) or `/kbuild` (the attended fallback). The milestone
+files are the interface contract between planning and execution. When a build surfaces a wrong
+planning assumption, that belongs in the handoff so the next kplan run absorbs it.
 </content>

--- a/src/devops_ai/cli/quality.py
+++ b/src/devops_ai/cli/quality.py
@@ -475,7 +475,7 @@ def generate_claude_hooks(plan: QualityPlan) -> str:
     Claude. Claude Code's built-in cap (8 consecutive blocks) breaks spins.
     """
     stop_cmd = (
-        'out=$(make check 2>&1) || { printf \'%s\\n\' "$out" | tail -40 >&2; '
+        'out=$(make check 2>&1) || { printf \'%s\\n\' "$out" | tail -n 40 >&2; '
         "echo 'make check failed — the turn cannot end red; fix and finish "
         "again.' >&2; exit 2; }"
     )

--- a/src/devops_ai/cli/quality.py
+++ b/src/devops_ai/cli/quality.py
@@ -228,11 +228,13 @@ def generate_justfile(plan: QualityPlan) -> str:
         ])
 
     check_deps = "quality test-unit"
+    check_comment = "# Full check: quality + unit tests"
     if plan.test_arch_cmd:
         check_deps += " test-arch"
+        check_comment += " + structural gates"
     lines.extend([
         "",
-        "# Full check: quality + unit tests + structural gates",
+        check_comment,
         f"check: {check_deps}",
     ])
 

--- a/src/devops_ai/cli/quality.py
+++ b/src/devops_ai/cli/quality.py
@@ -25,6 +25,8 @@ class QualityPlan:
     test_e2e_cmd: str | None
     fix_cmd: str | None
     setup_cmd: str
+    # Structural gates (tests/architecture/) — derived from the unit test command.
+    test_arch_cmd: str | None = None
 
 
 def detect_quality_config(project_root: Path) -> QualityPlan | None:
@@ -82,6 +84,9 @@ def detect_quality_config(project_root: Path) -> QualityPlan | None:
     # Derive setup command
     setup_cmd = _derive_setup_cmd(run)
 
+    # Derive structural-gates command from the unit test command
+    test_arch_cmd = _derive_test_arch_cmd(unit_tests)
+
     return QualityPlan(
         project_root=project_root,
         project_name=name or project_root.name,
@@ -93,6 +98,7 @@ def detect_quality_config(project_root: Path) -> QualityPlan | None:
         test_e2e_cmd=e2e_cmd,
         fix_cmd=fix_cmd,
         setup_cmd=setup_cmd,
+        test_arch_cmd=test_arch_cmd,
     )
 
 
@@ -142,6 +148,26 @@ def _derive_fix_cmd(lint_cmd: str, language: str) -> str | None:
     return None
 
 
+def _derive_test_arch_cmd(test_unit_cmd: str) -> str | None:
+    """Derive the structural-gates command (tests/architecture/) from the unit
+    test command. Only when the unit command names tests/unit — otherwise there
+    is no convention to map onto."""
+    if "tests/unit" in test_unit_cmd:
+        return test_unit_cmd.replace("tests/unit", "tests/architecture")
+    return None
+
+
+# Recipe shared by Makefile/Justfile: run the gates when the directory exists,
+# stay green (with a notice) for projects that haven't adopted them yet. Once
+# tests/architecture/ lands, the gates' own arming test takes over loud-failure.
+def _test_arch_recipe(test_arch_cmd: str) -> str:
+    return (
+        f"@if [ -d tests/architecture ]; then {test_arch_cmd}; "
+        'else echo "no tests/architecture/ yet — structural gates not adopted '
+        '(see devops-ai rules/structural-gates.md)"; fi'
+    )
+
+
 def _normalize_uv_cmd(cmd: str) -> str:
     """Normalize .venv/bin/X to uv run X for portability.
 
@@ -185,6 +211,14 @@ def generate_justfile(plan: QualityPlan) -> str:
         f"    {plan.test_unit_cmd}",
     ]
 
+    if plan.test_arch_cmd:
+        lines.extend([
+            "",
+            "# Structural gates (see devops-ai rules/structural-gates.md)",
+            "test-arch:",
+            f"    {_test_arch_recipe(plan.test_arch_cmd)}",
+        ])
+
     if plan.test_e2e_cmd:
         lines.extend([
             "",
@@ -193,10 +227,13 @@ def generate_justfile(plan: QualityPlan) -> str:
             f"    {plan.test_e2e_cmd}",
         ])
 
+    check_deps = "quality test-unit"
+    if plan.test_arch_cmd:
+        check_deps += " test-arch"
     lines.extend([
         "",
-        "# Full check: quality + unit tests",
-        "check: quality test-unit",
+        "# Full check: quality + unit tests + structural gates",
+        f"check: {check_deps}",
     ])
 
     if plan.fix_cmd:
@@ -221,6 +258,8 @@ def generate_justfile(plan: QualityPlan) -> str:
 def generate_makefile(plan: QualityPlan) -> str:
     """Generate Makefile content with standard quality targets."""
     targets = ["lint", "quality", "test-unit", "check", "setup"]
+    if plan.test_arch_cmd:
+        targets.append("test-arch")
     if plan.test_e2e_cmd:
         targets.append("test-e2e")
     if plan.fix_cmd:
@@ -241,6 +280,13 @@ def generate_makefile(plan: QualityPlan) -> str:
         f"\t{plan.test_unit_cmd}",
     ]
 
+    if plan.test_arch_cmd:
+        lines.extend([
+            "",
+            "test-arch:",
+            f"\t{_test_arch_recipe(plan.test_arch_cmd)}",
+        ])
+
     if plan.test_e2e_cmd:
         lines.extend([
             "",
@@ -248,9 +294,12 @@ def generate_makefile(plan: QualityPlan) -> str:
             f"\t{plan.test_e2e_cmd}",
         ])
 
+    check_deps = "quality test-unit"
+    if plan.test_arch_cmd:
+        check_deps += " test-arch"
     lines.extend([
         "",
-        "check: quality test-unit",
+        f"check: {check_deps}",
     ])
 
     if plan.fix_cmd:
@@ -419,7 +468,17 @@ def should_generate_conftest(project_root: Path) -> bool:
 
 
 def generate_claude_hooks(plan: QualityPlan) -> str:
-    """Generate Claude Code settings.json with Stop hook for lint."""
+    """Generate Claude Code settings.json with a blocking Stop hook.
+
+    The Stop hook is the mechanical half of the loop: exit code 2 blocks the
+    turn from ending while `make check` is red, feeding the failure back to
+    Claude. Claude Code's built-in cap (8 consecutive blocks) breaks spins.
+    """
+    stop_cmd = (
+        'out=$(make check 2>&1) || { printf \'%s\\n\' "$out" | tail -40 >&2; '
+        "echo 'make check failed — the turn cannot end red; fix and finish "
+        "again.' >&2; exit 2; }"
+    )
     data = {
         "hooks": {
             "Stop": [
@@ -427,8 +486,8 @@ def generate_claude_hooks(plan: QualityPlan) -> str:
                     "hooks": [
                         {
                             "type": "command",
-                            "command": "make lint",
-                            "timeout": 120,
+                            "command": stop_cmd,
+                            "timeout": 600,
                         },
                     ],
                 },

--- a/templates/acp.md
+++ b/templates/acp.md
@@ -1,0 +1,49 @@
+# ACP-NNN: <title>
+
+**Feature/milestone:** `<feature>/<Mx>` · **Task:** `<id>` · **Date:** YYYY-MM-DD
+**Status:** PROPOSED | ENDORSED | REFUTED | APPROVED | REJECTED
+
+<!-- An Architecture Change Proposal is written at the moment of contact with a design
+     that's wrong — by the agent that felt the friction. It is a proposal, not a license:
+     the task that spawned it continues under the CURRENT architecture, and the change,
+     if approved, lands as its own task with its own diff. Half a page, evidence-first. -->
+
+## Friction evidence
+
+<!-- What fought back, concretely: the contract or invariant you hit, the scenario the
+     design doesn't fit, the exception you would otherwise request — quote the gate
+     failure or the code. "I would have structured it differently" is not friction. -->
+
+## What's wrong (design level)
+
+<!-- The architectural decision that's wrong and why — not this task's inconvenience.
+     Name the decision as the design doc states it. -->
+
+## Proposed change
+
+## Enforcement delta  (required — no delta, no ACP)
+
+<!-- Exactly which contract changes: the invariant in test_invariants.py, the layering
+     rule, the statement in ARCHITECTURE.md. An evolution that changes no contract is
+     either a refactor (doesn't need an ACP) or a workaround (refused). -->
+
+## Migration & debt
+
+<!-- What existing code violates the new shape, and which named task/milestone pays it
+     down. An unpriced "later" is the TODO(M4) pattern that never lands — name the
+     milestone or ratchet it explicitly. -->
+
+## Critique  (critique agent — fresh context, adversarial by default)
+
+<!-- Verdict: ENDORSE / REFUTE / ENDORSE-WITH-CONDITIONS, with reasoning against each
+     lens: Is this the design's problem or this task's inconvenience? Does it create a
+     second way of doing something that already has a way? Does the enforcement delta
+     actually close the loop, or loosen a contract without replacing it? Is the
+     migration priced or hand-waved? -->
+
+## Decision  (Karl)
+
+<!-- APPROVED / REJECTED + date + conditions. Approved → schedule the change as its own
+     task; amend docs and contracts in that task's diff, not this file. Refuted ACPs
+     don't reach this section — they're logged in the handoff and the task proceeds
+     under the current design. -->

--- a/templates/test_invariants.py
+++ b/templates/test_invariants.py
@@ -1,0 +1,124 @@
+"""Architecture invariants — structural gates (see devops-ai `rules/structural-gates.md`).
+
+These tests gate code STRUCTURE the way ruff gates style: they fail red, you fix the code.
+Never fix a failure by editing a threshold, a contract, or the ratchet — widening anything
+requires explicit human sign-off, recorded in the handoff.
+
+Starter template: adjust SRC_ROOT and the CONTRACTS below to this project's
+ARCHITECTURE.md, delete contracts that don't apply, then delete this paragraph.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# --- Configuration -------------------------------------------------------------------
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
+
+MAX_FILE_LINES = 400
+MAX_CLASSES_PER_MODULE = 8
+
+# Layering contracts: (importing package prefix, forbidden import prefixes, reason).
+# Example: ("myapp.domain", ("myapp.api", "fastapi"), "domain stays transport-free")
+LAYERING: list[tuple[str, tuple[str, ...], str]] = []
+
+# Pattern uniqueness: (glob of files allowed to define it, class-name suffix, reason).
+# Example: ("results.py", "Result", "result types live in one module")
+UNIQUE_PATTERNS: list[tuple[str, str, str]] = []
+
+# Ratchet: violations that pre-date this gate, frozen at their size at introduction.
+# Entries may only be REMOVED (when the file comes into compliance) — never added or
+# raised. relative path -> line count at freeze time.
+FILE_LINES_RATCHET: dict[str, int] = {}
+
+
+# --- Helpers --------------------------------------------------------------------------
+
+
+def _source_files() -> list[Path]:
+    return [p for p in SRC_ROOT.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(SRC_ROOT))
+
+
+def _module_name(path: Path) -> str:
+    parts = path.relative_to(SRC_ROOT).with_suffix("").parts
+    return ".".join(parts[:-1] + (parts[-1],)).removesuffix(".__init__")
+
+
+def _imports(tree: ast.AST) -> list[str]:
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            names.append(node.module)
+    return names
+
+
+# --- Gates ----------------------------------------------------------------------------
+
+
+def test_file_budgets() -> None:
+    """No source file beyond MAX_FILE_LINES; ratcheted files may only shrink."""
+    over, stale_ratchet = [], []
+    for path in _source_files():
+        lines = len(path.read_text().splitlines())
+        frozen = FILE_LINES_RATCHET.get(_rel(path))
+        if frozen is not None:
+            if lines <= MAX_FILE_LINES:
+                stale_ratchet.append(_rel(path))  # compliant now — remove its entry
+            elif lines > frozen:
+                over.append(f"{_rel(path)}: {lines} lines (ratchet froze it at {frozen})")
+        elif lines > MAX_FILE_LINES:
+            over.append(f"{_rel(path)}: {lines} lines (max {MAX_FILE_LINES})")
+    assert not over, "File budget exceeded — split the module:\n" + "\n".join(over)
+    assert not stale_ratchet, (
+        "Ratchet entries now compliant — delete them so they can't regress:\n"
+        + "\n".join(stale_ratchet)
+    )
+
+
+def test_module_class_caps() -> None:
+    """No module collects more than MAX_CLASSES_PER_MODULE classes/dataclasses."""
+    over = []
+    for path in _source_files():
+        tree = ast.parse(path.read_text())
+        count = sum(isinstance(n, ast.ClassDef) for n in ast.iter_child_nodes(tree))
+        if count > MAX_CLASSES_PER_MODULE:
+            over.append(f"{_rel(path)}: {count} classes (max {MAX_CLASSES_PER_MODULE})")
+    assert not over, "Module shape violated — extract a package:\n" + "\n".join(over)
+
+
+def test_layering_contracts() -> None:
+    """Imports respect the layering declared in ARCHITECTURE.md."""
+    violations = []
+    for path in _source_files():
+        module = _module_name(path)
+        imported = _imports(ast.parse(path.read_text()))
+        for prefix, forbidden, reason in LAYERING:
+            if not module.startswith(prefix):
+                continue
+            for name in imported:
+                if name.startswith(forbidden):
+                    violations.append(f"{_rel(path)} imports {name} ({reason})")
+    assert not violations, "Layering contract violated:\n" + "\n".join(violations)
+
+
+def test_pattern_uniqueness() -> None:
+    """One mechanism per job: pattern-bearing classes live only where declared."""
+    violations = []
+    for path in _source_files():
+        tree = ast.parse(path.read_text())
+        classes = [n.name for n in ast.iter_child_nodes(tree) if isinstance(n, ast.ClassDef)]
+        for allowed_glob, suffix, reason in UNIQUE_PATTERNS:
+            if path.match(allowed_glob):
+                continue
+            for name in classes:
+                if name.endswith(suffix):
+                    violations.append(f"{_rel(path)}: class {name} ({reason})")
+    assert not violations, "Pattern uniqueness violated:\n" + "\n".join(violations)

--- a/templates/test_invariants.py
+++ b/templates/test_invariants.py
@@ -4,8 +4,9 @@ These tests gate code STRUCTURE the way ruff gates style: they fail red, you fix
 the code. Never fix a failure by editing a threshold, a contract, or the ratchet —
 widening anything requires explicit human sign-off, recorded in the handoff.
 
-Starter template: adjust SRC_ROOT and the CONTRACTS below to this project's
-ARCHITECTURE.md, delete contracts that don't apply, then delete this paragraph.
+Starter template: adjust SRC_ROOT and the Configuration block below (LAYERING,
+UNIQUE_PATTERNS, ratchets, …) to this project's ARCHITECTURE.md, delete entries
+that don't apply, then delete this paragraph.
 """
 
 from __future__ import annotations

--- a/templates/test_invariants.py
+++ b/templates/test_invariants.py
@@ -37,7 +37,9 @@ UNIQUE_PATTERNS: list[tuple[str, str, str]] = []
 FILE_LINES_RATCHET: dict[str, int] = {}
 
 # Test honesty (see the `tdd` rule): fakes at I/O seams, not patches everywhere.
-TESTS_ROOT = Path(__file__).resolve().parents[1]
+# The contract governs UNIT tests (the testing-taxonomy rule lets integration
+# tests use what they need) — widen to parents[1] for stricter enforcement.
+TESTS_ROOT = Path(__file__).resolve().parents[1] / "unit"
 MAX_PATCHES_PER_TEST_FILE = 5
 # Patching first-party code welds tests to internal structure. Set to your package
 # prefix(es), e.g. ("myapp",). Empty disables the gate.
@@ -67,6 +69,8 @@ def _module_name(path: Path) -> str:
 
 
 def _test_files() -> list[Path]:
+    if not TESTS_ROOT.is_dir():
+        return []
     me = Path(__file__).resolve()
     return [
         p

--- a/templates/test_invariants.py
+++ b/templates/test_invariants.py
@@ -33,6 +33,15 @@ UNIQUE_PATTERNS: list[tuple[str, str, str]] = []
 # raised. relative path -> line count at freeze time.
 FILE_LINES_RATCHET: dict[str, int] = {}
 
+# Test honesty (see the `tdd` rule): fakes at I/O seams, not patches everywhere.
+TESTS_ROOT = Path(__file__).resolve().parents[1]
+MAX_PATCHES_PER_TEST_FILE = 5
+# Patching first-party code welds tests to internal structure. Set to your package
+# prefix(es), e.g. ("myapp",). Empty disables the gate.
+FIRST_PARTY_PREFIXES: tuple[str, ...] = ()
+# Pre-existing offenders, frozen: test file -> patch count at freeze time.
+PATCH_RATCHET: dict[str, int] = {}
+
 
 # --- Helpers --------------------------------------------------------------------------
 
@@ -48,6 +57,43 @@ def _rel(path: Path) -> str:
 def _module_name(path: Path) -> str:
     parts = path.relative_to(SRC_ROOT).with_suffix("").parts
     return ".".join(parts[:-1] + (parts[-1],)).removesuffix(".__init__")
+
+
+def _test_files() -> list[Path]:
+    me = Path(__file__).resolve()
+    return [
+        p
+        for p in TESTS_ROOT.rglob("test_*.py")
+        if "__pycache__" not in p.parts and p.resolve() != me
+    ]
+
+
+def _patch_calls(tree: ast.AST) -> list[ast.Call]:
+    """Calls that patch running code: patch(), mock.patch[.object/.dict](),
+    monkeypatch.setattr(). Approximate by design — it gates density, not usage."""
+    calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        f = node.func
+        is_patch = (
+            (isinstance(f, ast.Name) and f.id == "patch")
+            or (isinstance(f, ast.Attribute) and f.attr == "patch")
+            or (
+                isinstance(f, ast.Attribute)
+                and isinstance(f.value, ast.Name)
+                and f.value.id == "patch"  # patch.object / patch.dict
+            )
+            or (
+                isinstance(f, ast.Attribute)
+                and f.attr == "setattr"
+                and isinstance(f.value, ast.Name)
+                and f.value.id == "monkeypatch"
+            )
+        )
+        if is_patch:
+            calls.append(node)
+    return calls
 
 
 def _imports(tree: ast.AST) -> list[str]:
@@ -107,6 +153,53 @@ def test_layering_contracts() -> None:
                 if name.startswith(forbidden):
                     violations.append(f"{_rel(path)} imports {name} ({reason})")
     assert not violations, "Layering contract violated:\n" + "\n".join(violations)
+
+
+def test_patch_density() -> None:
+    """Patching is a coupling smell; fakes at I/O seams keep tests refactor-proof."""
+    over, stale_ratchet = [], []
+    for path in _test_files():
+        rel = str(path.relative_to(TESTS_ROOT))
+        count = len(_patch_calls(ast.parse(path.read_text())))
+        frozen = PATCH_RATCHET.get(rel)
+        if frozen is not None:
+            if count <= MAX_PATCHES_PER_TEST_FILE:
+                stale_ratchet.append(rel)  # compliant now — remove its entry
+            elif count > frozen:
+                over.append(f"{rel}: {count} patches (ratchet froze it at {frozen})")
+        elif count > MAX_PATCHES_PER_TEST_FILE:
+            over.append(f"{rel}: {count} patches (max {MAX_PATCHES_PER_TEST_FILE})")
+    assert not over, (
+        "Patch density exceeded — replace patches with fakes at the I/O seam:\n"
+        + "\n".join(over)
+    )
+    assert not stale_ratchet, (
+        "Ratchet entries now compliant — delete them so they can't regress:\n"
+        + "\n".join(stale_ratchet)
+    )
+
+
+def test_no_first_party_patching() -> None:
+    """patch("yourpkg.x.y") welds the test to internal structure — use a fake."""
+    if not FIRST_PARTY_PREFIXES:
+        return
+    violations = []
+    for path in _test_files():
+        rel = str(path.relative_to(TESTS_ROOT))
+        if rel in PATCH_RATCHET:  # frozen offenders shrink via test_patch_density
+            continue
+        for call in _patch_calls(ast.parse(path.read_text())):
+            target = call.args[0] if call.args else None
+            if (
+                isinstance(target, ast.Constant)
+                and isinstance(target.value, str)
+                and target.value.startswith(FIRST_PARTY_PREFIXES)
+            ):
+                violations.append(f"{rel}: patches {target.value}")
+    assert not violations, (
+        "First-party patching — test through the public surface instead:\n"
+        + "\n".join(violations)
+    )
 
 
 def test_pattern_uniqueness() -> None:

--- a/templates/test_invariants.py
+++ b/templates/test_invariants.py
@@ -1,8 +1,8 @@
-"""Architecture invariants — structural gates (see devops-ai `rules/structural-gates.md`).
+"""Architecture invariants — structural gates (devops-ai `rules/structural-gates.md`).
 
-These tests gate code STRUCTURE the way ruff gates style: they fail red, you fix the code.
-Never fix a failure by editing a threshold, a contract, or the ratchet — widening anything
-requires explicit human sign-off, recorded in the handoff.
+These tests gate code STRUCTURE the way ruff gates style: they fail red, you fix
+the code. Never fix a failure by editing a threshold, a contract, or the ratchet —
+widening anything requires explicit human sign-off, recorded in the handoff.
 
 Starter template: adjust SRC_ROOT and the CONTRACTS below to this project's
 ARCHITECTURE.md, delete contracts that don't apply, then delete this paragraph.
@@ -21,6 +21,8 @@ MAX_FILE_LINES = 400
 MAX_CLASSES_PER_MODULE = 8
 
 # Layering contracts: (importing package prefix, forbidden import prefixes, reason).
+# Prefixes match on module boundaries: "myapp.api" forbids "myapp.api.routes" but
+# not "myapp.apiclient". Relative imports are resolved before checking.
 # Example: ("myapp.domain", ("myapp.api", "fastapi"), "domain stays transport-free")
 LAYERING: list[tuple[str, tuple[str, ...], str]] = []
 
@@ -41,12 +43,16 @@ MAX_PATCHES_PER_TEST_FILE = 5
 FIRST_PARTY_PREFIXES: tuple[str, ...] = ()
 # Pre-existing offenders, frozen: test file -> patch count at freeze time.
 PATCH_RATCHET: dict[str, int] = {}
+# Pre-existing first-party patching, frozen: test file -> first-party patch count.
+FIRST_PARTY_PATCH_RATCHET: dict[str, int] = {}
 
 
 # --- Helpers --------------------------------------------------------------------------
 
 
 def _source_files() -> list[Path]:
+    if not SRC_ROOT.is_dir():
+        return []
     return [p for p in SRC_ROOT.rglob("*.py") if "__pycache__" not in p.parts]
 
 
@@ -56,33 +62,62 @@ def _rel(path: Path) -> str:
 
 def _module_name(path: Path) -> str:
     parts = path.relative_to(SRC_ROOT).with_suffix("").parts
-    return ".".join(parts[:-1] + (parts[-1],)).removesuffix(".__init__")
+    return ".".join(parts).removesuffix(".__init__")
 
 
 def _test_files() -> list[Path]:
     me = Path(__file__).resolve()
     return [
         p
-        for p in TESTS_ROOT.rglob("test_*.py")
+        for pattern in ("test_*.py", "conftest.py")
+        for p in sorted(TESTS_ROOT.rglob(pattern))
         if "__pycache__" not in p.parts and p.resolve() != me
     ]
 
 
+def _parse_or_none(path: Path) -> ast.AST | None:
+    """Parse a file, or return None — test_gates_are_armed reports the failures,
+    so one broken file doesn't crash every gate with the same stack trace."""
+    try:
+        return ast.parse(path.read_text())
+    except SyntaxError:
+        return None
+
+
+def _within(name: str, prefix: str) -> bool:
+    """Module-boundary prefix match: 'myapp.api' covers 'myapp.api.routes',
+    not 'myapp.apiclient'."""
+    return name == prefix or name.startswith(prefix + ".")
+
+
 def _patch_calls(tree: ast.AST) -> list[ast.Call]:
-    """Calls that patch running code: patch(), mock.patch[.object/.dict](),
-    monkeypatch.setattr(). Approximate by design — it gates density, not usage."""
+    """Calls that patch running code: patch()/patch.object()/patch.dict() — bare,
+    aliased, or via mock/mocker — plus monkeypatch.setattr(). Approximate by design."""
+    aliases = {"patch"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module in ("unittest.mock", "mock"):
+                aliases.update(
+                    a.asname or a.name for a in node.names if a.name == "patch"
+                )
+
+    def is_patch_ref(f: ast.expr) -> bool:
+        # `patch` / an alias of it / `mock.patch` / `mocker.patch`
+        return (isinstance(f, ast.Name) and f.id in aliases) or (
+            isinstance(f, ast.Attribute) and f.attr == "patch"
+        )
+
     calls = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         f = node.func
         is_patch = (
-            (isinstance(f, ast.Name) and f.id == "patch")
-            or (isinstance(f, ast.Attribute) and f.attr == "patch")
+            is_patch_ref(f)
             or (
                 isinstance(f, ast.Attribute)
-                and isinstance(f.value, ast.Name)
-                and f.value.id == "patch"  # patch.object / patch.dict
+                and f.attr in ("object", "dict")
+                and is_patch_ref(f.value)
             )
             or (
                 isinstance(f, ast.Attribute)
@@ -96,17 +131,104 @@ def _patch_calls(tree: ast.AST) -> list[ast.Call]:
     return calls
 
 
-def _imports(tree: ast.AST) -> list[str]:
+def _local_imports(tree: ast.AST) -> dict[str, str]:
+    """Local name -> dotted path it was imported as, for resolving patch.object
+    targets like `patch.object(services, "save")` back to real modules."""
+    out: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                if a.asname:
+                    out[a.asname] = a.name
+                else:
+                    root = a.name.split(".")[0]
+                    out[root] = root
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            for a in node.names:
+                out[a.asname or a.name] = f"{node.module}.{a.name}"
+    return out
+
+
+def _dotted(node: ast.expr) -> str | None:
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _first_party_target(call: ast.Call, imports: dict[str, str]) -> str | None:
+    """The first-party thing this call patches, or None. Resolves string targets,
+    bare names, and dotted expressions through the file's imports."""
+    if not call.args:
+        return None
+    target = call.args[0]
+    if isinstance(target, ast.Constant) and isinstance(target.value, str):
+        name = target.value
+    else:
+        dotted = _dotted(target)
+        if dotted is None:
+            return None
+        root, _, rest = dotted.partition(".")
+        resolved = imports.get(root)
+        if resolved is None:
+            return None
+        name = f"{resolved}.{rest}" if rest else resolved
+    if any(_within(name, prefix) for prefix in FIRST_PARTY_PREFIXES):
+        return name
+    return None
+
+
+def _imports(tree: ast.AST, package: str) -> list[str]:
+    """All imported module names, with relative imports resolved against `package`
+    (the dotted package containing the file)."""
     names: list[str] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             names.extend(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
-            names.append(node.module)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                names.append(node.module)
+            elif node.level:
+                parts = package.split(".") if package else []
+                if node.level - 1 > len(parts):
+                    continue  # escapes SRC_ROOT — nothing to resolve against
+                base_parts = parts[: len(parts) - (node.level - 1)]
+                base = ".".join(base_parts)
+                if node.module:
+                    names.append(f"{base}.{node.module}" if base else node.module)
+                else:
+                    names.extend(
+                        f"{base}.{a.name}" if base else a.name for a in node.names
+                    )
     return names
 
 
+def _package(path: Path) -> str:
+    return ".".join(path.parent.relative_to(SRC_ROOT).parts)
+
+
 # --- Gates ----------------------------------------------------------------------------
+
+
+def test_gates_are_armed() -> None:
+    """Misconfiguration must fail loudly: a missing SRC_ROOT or an unparseable file
+    would silently exempt code from every gate below."""
+    assert SRC_ROOT.is_dir(), (
+        f"SRC_ROOT not found: {SRC_ROOT} — fix the path at the top of this file"
+    )
+    files = _source_files()
+    assert files, f"No Python sources under {SRC_ROOT} — the gates are checking nothing"
+    bad = [_rel(p) for p in files if _parse_or_none(p) is None]
+    bad += [
+        str(p.relative_to(TESTS_ROOT))
+        for p in _test_files()
+        if _parse_or_none(p) is None
+    ]
+    assert not bad, "Unparseable files are exempt from every gate:\n" + "\n".join(bad)
 
 
 def test_file_budgets() -> None:
@@ -119,7 +241,9 @@ def test_file_budgets() -> None:
             if lines <= MAX_FILE_LINES:
                 stale_ratchet.append(_rel(path))  # compliant now — remove its entry
             elif lines > frozen:
-                over.append(f"{_rel(path)}: {lines} lines (ratchet froze it at {frozen})")
+                over.append(
+                    f"{_rel(path)}: {lines} lines (ratchet froze it at {frozen})"
+                )
         elif lines > MAX_FILE_LINES:
             over.append(f"{_rel(path)}: {lines} lines (max {MAX_FILE_LINES})")
     assert not over, "File budget exceeded — split the module:\n" + "\n".join(over)
@@ -130,11 +254,14 @@ def test_file_budgets() -> None:
 
 
 def test_module_class_caps() -> None:
-    """No module collects more than MAX_CLASSES_PER_MODULE classes/dataclasses."""
+    """No module collects more than MAX_CLASSES_PER_MODULE classes/dataclasses
+    (nested classes count — a god-file hidden inside one class is still a god-file)."""
     over = []
     for path in _source_files():
-        tree = ast.parse(path.read_text())
-        count = sum(isinstance(n, ast.ClassDef) for n in ast.iter_child_nodes(tree))
+        tree = _parse_or_none(path)
+        if tree is None:
+            continue
+        count = sum(isinstance(n, ast.ClassDef) for n in ast.walk(tree))
         if count > MAX_CLASSES_PER_MODULE:
             over.append(f"{_rel(path)}: {count} classes (max {MAX_CLASSES_PER_MODULE})")
     assert not over, "Module shape violated — extract a package:\n" + "\n".join(over)
@@ -144,13 +271,16 @@ def test_layering_contracts() -> None:
     """Imports respect the layering declared in ARCHITECTURE.md."""
     violations = []
     for path in _source_files():
+        tree = _parse_or_none(path)
+        if tree is None:
+            continue
         module = _module_name(path)
-        imported = _imports(ast.parse(path.read_text()))
+        imported = _imports(tree, _package(path))
         for prefix, forbidden, reason in LAYERING:
-            if not module.startswith(prefix):
+            if not _within(module, prefix):
                 continue
             for name in imported:
-                if name.startswith(forbidden):
+                if any(_within(name, f) for f in forbidden):
                     violations.append(f"{_rel(path)} imports {name} ({reason})")
     assert not violations, "Layering contract violated:\n" + "\n".join(violations)
 
@@ -160,7 +290,10 @@ def test_patch_density() -> None:
     over, stale_ratchet = [], []
     for path in _test_files():
         rel = str(path.relative_to(TESTS_ROOT))
-        count = len(_patch_calls(ast.parse(path.read_text())))
+        tree = _parse_or_none(path)
+        if tree is None:
+            continue
+        count = len(_patch_calls(tree))
         frozen = PATCH_RATCHET.get(rel)
         if frozen is not None:
             if count <= MAX_PATCHES_PER_TEST_FILE:
@@ -180,25 +313,40 @@ def test_patch_density() -> None:
 
 
 def test_no_first_party_patching() -> None:
-    """patch("yourpkg.x.y") welds the test to internal structure — use a fake."""
+    """patch("yourpkg.x.y") — or patch.object(yourmodule, "y") — welds the test to
+    internal structure; use a fake at the I/O seam instead."""
     if not FIRST_PARTY_PREFIXES:
         return
-    violations = []
+    violations, stale_ratchet = [], []
     for path in _test_files():
         rel = str(path.relative_to(TESTS_ROOT))
-        if rel in PATCH_RATCHET:  # frozen offenders shrink via test_patch_density
+        tree = _parse_or_none(path)
+        if tree is None:
             continue
-        for call in _patch_calls(ast.parse(path.read_text())):
-            target = call.args[0] if call.args else None
-            if (
-                isinstance(target, ast.Constant)
-                and isinstance(target.value, str)
-                and target.value.startswith(FIRST_PARTY_PREFIXES)
-            ):
-                violations.append(f"{rel}: patches {target.value}")
+        imports = _local_imports(tree)
+        hits = [
+            target
+            for call in _patch_calls(tree)
+            if (target := _first_party_target(call, imports)) is not None
+        ]
+        frozen = FIRST_PARTY_PATCH_RATCHET.get(rel)
+        if frozen is not None:
+            if not hits:
+                stale_ratchet.append(rel)  # compliant now — remove its entry
+            elif len(hits) > frozen:
+                violations.append(
+                    f"{rel}: {len(hits)} first-party patches "
+                    f"(ratchet froze it at {frozen})"
+                )
+        else:
+            violations.extend(f"{rel}: patches {target}" for target in hits)
     assert not violations, (
         "First-party patching — test through the public surface instead:\n"
         + "\n".join(violations)
+    )
+    assert not stale_ratchet, (
+        "Ratchet entries now compliant — delete them so they can't regress:\n"
+        + "\n".join(stale_ratchet)
     )
 
 
@@ -206,8 +354,10 @@ def test_pattern_uniqueness() -> None:
     """One mechanism per job: pattern-bearing classes live only where declared."""
     violations = []
     for path in _source_files():
-        tree = ast.parse(path.read_text())
-        classes = [n.name for n in ast.iter_child_nodes(tree) if isinstance(n, ast.ClassDef)]
+        tree = _parse_or_none(path)
+        if tree is None:
+            continue
+        classes = [n.name for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]
         for allowed_glob, suffix, reason in UNIQUE_PATTERNS:
             if path.match(allowed_glob):
                 continue

--- a/tests/unit/test_invariants_template.py
+++ b/tests/unit/test_invariants_template.py
@@ -25,7 +25,7 @@ def load_gates(tmp_path: Path, **overrides: object) -> ModuleType:
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     mod.SRC_ROOT = tmp_path / "src"
-    mod.TESTS_ROOT = tmp_path / "tests"
+    mod.TESTS_ROOT = tmp_path / "tests" / "unit"  # the template's default scope
     for key, value in overrides.items():
         setattr(mod, key, value)
     return mod
@@ -43,7 +43,6 @@ def write(root: Path, rel: str, text: str = "") -> Path:
 
 def test_armed_fails_when_src_root_missing(tmp_path: Path) -> None:
     mod = load_gates(tmp_path)
-    (tmp_path / "tests").mkdir()
     with pytest.raises(AssertionError, match="SRC_ROOT"):
         mod.test_gates_are_armed()
 
@@ -51,16 +50,15 @@ def test_armed_fails_when_src_root_missing(tmp_path: Path) -> None:
 def test_armed_fails_when_src_root_empty(tmp_path: Path) -> None:
     mod = load_gates(tmp_path)
     (tmp_path / "src").mkdir()
-    (tmp_path / "tests").mkdir()
     with pytest.raises(AssertionError, match="[Nn]o Python"):
         mod.test_gates_are_armed()
 
 
 def test_armed_reports_unparseable_files(tmp_path: Path) -> None:
+    # no tests/unit dir either — _test_files() must tolerate it
     mod = load_gates(tmp_path)
     write(tmp_path, "src/myapp/good.py", "x = 1\n")
     write(tmp_path, "src/myapp/broken.py", "def (\n")
-    (tmp_path / "tests").mkdir()
     with pytest.raises(AssertionError, match="broken.py"):
         mod.test_gates_are_armed()
     # other gates skip the unparseable file instead of crashing every gate
@@ -113,6 +111,40 @@ def test_conftest_is_scanned_for_density(tmp_path: Path) -> None:
     )
     with pytest.raises(AssertionError, match="conftest.py"):
         mod.test_patch_density()
+
+
+def test_default_scope_is_unit_tests() -> None:
+    """The template's own default TESTS_ROOT must target tests/unit/ — the
+    loader override above can't catch a wrong default."""
+    spec = importlib.util.spec_from_file_location("invariants_default", TEMPLATE_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    # copied to tests/architecture/, parents[1] is tests/ — default scope is unit/
+    assert mod.TESTS_ROOT == TEMPLATE_PATH.resolve().parents[1] / "unit"
+
+
+def test_integration_tests_not_governed(tmp_path: Path) -> None:
+    """Test honesty is the unit-test contract (tdd rule) — integration tests may
+    patch freely and must not trip the gates with the default scope."""
+    mod = load_gates(
+        tmp_path, MAX_PATCHES_PER_TEST_FILE=1, FIRST_PARTY_PREFIXES=("myapp",)
+    )
+    write(tmp_path, "src/myapp/a.py", "x = 1\n")
+    write(
+        tmp_path,
+        "tests/integration/test_real_adapter.py",
+        """
+        from unittest.mock import patch
+
+        def test_t():
+            with patch("myapp.services.save"):
+                with patch("myapp.services.load"):
+                    pass
+        """,
+    )
+    mod.test_patch_density()
+    mod.test_no_first_party_patching()
 
 
 # --- First-party patching ---
@@ -206,7 +238,7 @@ def test_first_party_ratchet_frozen_offenders(tmp_path: Path) -> None:
     mod = load_gates(
         tmp_path,
         FIRST_PARTY_PREFIXES=("myapp",),
-        FIRST_PARTY_PATCH_RATCHET={"unit/test_old.py": 2},
+        FIRST_PARTY_PATCH_RATCHET={"test_old.py": 2},
     )
     write(tmp_path, "src/myapp/a.py", "x = 1\n")
     write(tmp_path, "tests/unit/test_old.py", src)
@@ -215,7 +247,7 @@ def test_first_party_ratchet_frozen_offenders(tmp_path: Path) -> None:
     mod_over = load_gates(
         tmp_path,
         FIRST_PARTY_PREFIXES=("myapp",),
-        FIRST_PARTY_PATCH_RATCHET={"unit/test_old.py": 1},
+        FIRST_PARTY_PATCH_RATCHET={"test_old.py": 1},
     )
     with pytest.raises(AssertionError, match="ratchet"):
         mod_over.test_no_first_party_patching()
@@ -225,7 +257,7 @@ def test_first_party_ratchet_stale_entry_flagged(tmp_path: Path) -> None:
     mod = load_gates(
         tmp_path,
         FIRST_PARTY_PREFIXES=("myapp",),
-        FIRST_PARTY_PATCH_RATCHET={"unit/test_old.py": 2},
+        FIRST_PARTY_PATCH_RATCHET={"test_old.py": 2},
     )
     write(tmp_path, "src/myapp/a.py", "x = 1\n")
     write(tmp_path, "tests/unit/test_old.py", "def test_t():\n    pass\n")
@@ -241,7 +273,6 @@ def test_layering_resolves_relative_imports(tmp_path: Path) -> None:
         tmp_path,
         LAYERING=[("myapp.domain", ("myapp.api",), "domain stays transport-free")],
     )
-    (tmp_path / "tests").mkdir()
     write(tmp_path, "src/myapp/api/routes.py", "x = 1\n")
     write(tmp_path, "src/myapp/domain/logic.py", "from ..api import routes\n")
     with pytest.raises(AssertionError, match="myapp.api"):
@@ -253,7 +284,6 @@ def test_layering_prefix_requires_dot_boundary(tmp_path: Path) -> None:
         tmp_path,
         LAYERING=[("myapp.domain", ("myapp.api",), "domain stays transport-free")],
     )
-    (tmp_path / "tests").mkdir()
     write(tmp_path, "src/myapp/domain/logic.py", "import myapp.apiclient\n")
     mod.test_layering_contracts()  # apiclient is not api — must pass
 
@@ -263,7 +293,6 @@ def test_layering_absolute_import_still_caught(tmp_path: Path) -> None:
         tmp_path,
         LAYERING=[("myapp.domain", ("myapp.api", "fastapi"), "transport-free")],
     )
-    (tmp_path / "tests").mkdir()
     write(tmp_path, "src/myapp/domain/logic.py", "from fastapi import APIRouter\n")
     with pytest.raises(AssertionError, match="fastapi"):
         mod.test_layering_contracts()
@@ -274,7 +303,6 @@ def test_layering_absolute_import_still_caught(tmp_path: Path) -> None:
 
 def test_class_caps_count_nested_classes(tmp_path: Path) -> None:
     mod = load_gates(tmp_path, MAX_CLASSES_PER_MODULE=1)
-    (tmp_path / "tests").mkdir()
     write(
         tmp_path,
         "src/myapp/shapes.py",
@@ -293,7 +321,6 @@ def test_pattern_uniqueness_sees_nested_classes(tmp_path: Path) -> None:
         tmp_path,
         UNIQUE_PATTERNS=[("results.py", "Result", "result types live in results.py")],
     )
-    (tmp_path / "tests").mkdir()
     write(
         tmp_path,
         "src/myapp/service.py",
@@ -311,7 +338,6 @@ def test_pattern_uniqueness_sees_nested_classes(tmp_path: Path) -> None:
 
 
 def test_file_budget_ratchet_growth_and_stale(tmp_path: Path) -> None:
-    (tmp_path / "tests").mkdir()
     # frozen file may not grow past its freeze point
     mod = load_gates(
         tmp_path, MAX_FILE_LINES=2, FILE_LINES_RATCHET={"myapp/big.py": 4}

--- a/tests/unit/test_invariants_template.py
+++ b/tests/unit/test_invariants_template.py
@@ -1,0 +1,328 @@
+"""Tests for the structural-gates template (templates/test_invariants.py).
+
+The template is the verifier that autonomous loops converge on — an enforcement
+gap here is a hole optimization pressure will find. These tests load the template
+as a module, point it at synthetic project trees, and prove each gate fails when
+it must and stays quiet when it should.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import textwrap
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "test_invariants.py"
+
+
+def load_gates(tmp_path: Path, **overrides: object) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("invariants_template", TEMPLATE_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.SRC_ROOT = tmp_path / "src"
+    mod.TESTS_ROOT = tmp_path / "tests"
+    for key, value in overrides.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def write(root: Path, rel: str, text: str = "") -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text))
+    return path
+
+
+# --- Arming: gates must fail loudly when checking nothing ---
+
+
+def test_armed_fails_when_src_root_missing(tmp_path: Path) -> None:
+    mod = load_gates(tmp_path)
+    (tmp_path / "tests").mkdir()
+    with pytest.raises(AssertionError, match="SRC_ROOT"):
+        mod.test_gates_are_armed()
+
+
+def test_armed_fails_when_src_root_empty(tmp_path: Path) -> None:
+    mod = load_gates(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    with pytest.raises(AssertionError, match="[Nn]o Python"):
+        mod.test_gates_are_armed()
+
+
+def test_armed_reports_unparseable_files(tmp_path: Path) -> None:
+    mod = load_gates(tmp_path)
+    write(tmp_path, "src/myapp/good.py", "x = 1\n")
+    write(tmp_path, "src/myapp/broken.py", "def (\n")
+    (tmp_path / "tests").mkdir()
+    with pytest.raises(AssertionError, match="broken.py"):
+        mod.test_gates_are_armed()
+    # other gates skip the unparseable file instead of crashing every gate
+    mod.test_module_class_caps()
+    mod.test_layering_contracts()
+    mod.test_pattern_uniqueness()
+
+
+# --- Patch detection ---
+
+
+def test_patch_calls_counts_all_forms(tmp_path: Path) -> None:
+    mod = load_gates(tmp_path)
+    tree = ast.parse(
+        textwrap.dedent(
+            """
+            import mock
+            from unittest.mock import patch
+            from unittest.mock import patch as p
+
+            def test_everything(mocker, monkeypatch):
+                p("a")
+                patch("b")
+                mock.patch("c")
+                patch.object(svc, "d")
+                patch.dict("os.environ", {})
+                mock.patch.object(svc, "e")
+                mocker.patch("f")
+                mocker.patch.object(svc, "g")
+                monkeypatch.setattr(svc, "h", 1)
+            """
+        )
+    )
+    assert len(mod._patch_calls(tree)) == 9
+
+
+def test_conftest_is_scanned_for_density(tmp_path: Path) -> None:
+    mod = load_gates(tmp_path, MAX_PATCHES_PER_TEST_FILE=1)
+    write(tmp_path, "src/myapp/a.py", "x = 1\n")
+    write(
+        tmp_path,
+        "tests/unit/conftest.py",
+        """
+        from unittest.mock import patch
+
+        def setup():
+            patch("a")
+            patch("b")
+        """,
+    )
+    with pytest.raises(AssertionError, match="conftest.py"):
+        mod.test_patch_density()
+
+
+# --- First-party patching ---
+
+
+def test_first_party_patch_object_via_from_import(tmp_path: Path) -> None:
+    mod = load_gates(tmp_path, FIRST_PARTY_PREFIXES=("myapp",))
+    write(tmp_path, "src/myapp/a.py", "x = 1\n")
+    write(
+        tmp_path,
+        "tests/unit/test_x.py",
+        """
+        from unittest.mock import patch
+        from myapp import services
+
+        def test_t():
+            with patch.object(services, "save"):
+                pass
+        """,
+    )
+    with pytest.raises(AssertionError, match="myapp.services"):
+        mod.test_no_first_party_patching()
+
+
+def test_first_party_patch_object_via_module_alias(tmp_path: Path) -> None:
+    mod = load_gates(tmp_path, FIRST_PARTY_PREFIXES=("myapp",))
+    write(tmp_path, "src/myapp/a.py", "x = 1\n")
+    write(
+        tmp_path,
+        "tests/unit/test_x.py",
+        """
+        from unittest.mock import patch
+        import myapp.services as services
+
+        def test_t():
+            with patch.object(services, "save"):
+                pass
+        """,
+    )
+    with pytest.raises(AssertionError, match="myapp.services"):
+        mod.test_no_first_party_patching()
+
+
+def test_first_party_string_requires_dot_boundary(tmp_path: Path) -> None:
+    mod = load_gates(tmp_path, FIRST_PARTY_PREFIXES=("myapp",))
+    write(tmp_path, "src/myapp/a.py", "x = 1\n")
+    write(
+        tmp_path,
+        "tests/unit/test_x.py",
+        """
+        from unittest.mock import patch
+
+        def test_t():
+            with patch("myapplib.thing"):
+                pass
+        """,
+    )
+    mod.test_no_first_party_patching()  # myapplib is not myapp — must pass
+
+
+def test_third_party_patching_allowed(tmp_path: Path) -> None:
+    mod = load_gates(tmp_path, FIRST_PARTY_PREFIXES=("myapp",))
+    write(tmp_path, "src/myapp/a.py", "x = 1\n")
+    write(
+        tmp_path,
+        "tests/unit/test_x.py",
+        """
+        from unittest.mock import patch
+        import requests
+
+        def test_t():
+            with patch.object(requests, "get"):
+                pass
+        """,
+    )
+    mod.test_no_first_party_patching()
+
+
+def test_first_party_ratchet_frozen_offenders(tmp_path: Path) -> None:
+    src = """
+        from unittest.mock import patch
+        from myapp import services
+
+        def test_t():
+            with patch.object(services, "save"):
+                pass
+            with patch.object(services, "load"):
+                pass
+        """
+    # within the frozen allowance: passes
+    mod = load_gates(
+        tmp_path,
+        FIRST_PARTY_PREFIXES=("myapp",),
+        FIRST_PARTY_PATCH_RATCHET={"unit/test_old.py": 2},
+    )
+    write(tmp_path, "src/myapp/a.py", "x = 1\n")
+    write(tmp_path, "tests/unit/test_old.py", src)
+    mod.test_no_first_party_patching()
+    # above the frozen allowance: fails
+    mod_over = load_gates(
+        tmp_path,
+        FIRST_PARTY_PREFIXES=("myapp",),
+        FIRST_PARTY_PATCH_RATCHET={"unit/test_old.py": 1},
+    )
+    with pytest.raises(AssertionError, match="ratchet"):
+        mod_over.test_no_first_party_patching()
+
+
+def test_first_party_ratchet_stale_entry_flagged(tmp_path: Path) -> None:
+    mod = load_gates(
+        tmp_path,
+        FIRST_PARTY_PREFIXES=("myapp",),
+        FIRST_PARTY_PATCH_RATCHET={"unit/test_old.py": 2},
+    )
+    write(tmp_path, "src/myapp/a.py", "x = 1\n")
+    write(tmp_path, "tests/unit/test_old.py", "def test_t():\n    pass\n")
+    with pytest.raises(AssertionError, match="[Rr]atchet entries now compliant"):
+        mod.test_no_first_party_patching()
+
+
+# --- Layering ---
+
+
+def test_layering_resolves_relative_imports(tmp_path: Path) -> None:
+    mod = load_gates(
+        tmp_path,
+        LAYERING=[("myapp.domain", ("myapp.api",), "domain stays transport-free")],
+    )
+    (tmp_path / "tests").mkdir()
+    write(tmp_path, "src/myapp/api/routes.py", "x = 1\n")
+    write(tmp_path, "src/myapp/domain/logic.py", "from ..api import routes\n")
+    with pytest.raises(AssertionError, match="myapp.api"):
+        mod.test_layering_contracts()
+
+
+def test_layering_prefix_requires_dot_boundary(tmp_path: Path) -> None:
+    mod = load_gates(
+        tmp_path,
+        LAYERING=[("myapp.domain", ("myapp.api",), "domain stays transport-free")],
+    )
+    (tmp_path / "tests").mkdir()
+    write(tmp_path, "src/myapp/domain/logic.py", "import myapp.apiclient\n")
+    mod.test_layering_contracts()  # apiclient is not api — must pass
+
+
+def test_layering_absolute_import_still_caught(tmp_path: Path) -> None:
+    mod = load_gates(
+        tmp_path,
+        LAYERING=[("myapp.domain", ("myapp.api", "fastapi"), "transport-free")],
+    )
+    (tmp_path / "tests").mkdir()
+    write(tmp_path, "src/myapp/domain/logic.py", "from fastapi import APIRouter\n")
+    with pytest.raises(AssertionError, match="fastapi"):
+        mod.test_layering_contracts()
+
+
+# --- Module shape & pattern uniqueness ---
+
+
+def test_class_caps_count_nested_classes(tmp_path: Path) -> None:
+    mod = load_gates(tmp_path, MAX_CLASSES_PER_MODULE=1)
+    (tmp_path / "tests").mkdir()
+    write(
+        tmp_path,
+        "src/myapp/shapes.py",
+        """
+        class Outer:
+            class Inner:
+                pass
+        """,
+    )
+    with pytest.raises(AssertionError, match="2 classes"):
+        mod.test_module_class_caps()
+
+
+def test_pattern_uniqueness_sees_nested_classes(tmp_path: Path) -> None:
+    mod = load_gates(
+        tmp_path,
+        UNIQUE_PATTERNS=[("results.py", "Result", "result types live in results.py")],
+    )
+    (tmp_path / "tests").mkdir()
+    write(
+        tmp_path,
+        "src/myapp/service.py",
+        """
+        class Service:
+            class FetchResult:
+                pass
+        """,
+    )
+    with pytest.raises(AssertionError, match="FetchResult"):
+        mod.test_pattern_uniqueness()
+
+
+# --- File budgets ---
+
+
+def test_file_budget_ratchet_growth_and_stale(tmp_path: Path) -> None:
+    (tmp_path / "tests").mkdir()
+    # frozen file may not grow past its freeze point
+    mod = load_gates(
+        tmp_path, MAX_FILE_LINES=2, FILE_LINES_RATCHET={"myapp/big.py": 4}
+    )
+    write(tmp_path, "src/myapp/big.py", "a = 1\nb = 2\nc = 3\nd = 4\ne = 5\n")
+    with pytest.raises(AssertionError, match="ratchet froze it at 4"):
+        mod.test_file_budgets()
+    # compliant file with a leftover ratchet entry is flagged for removal
+    mod_stale = load_gates(
+        tmp_path, MAX_FILE_LINES=2, FILE_LINES_RATCHET={"myapp/big.py": 4}
+    )
+    write(tmp_path, "src/myapp/big.py", "a = 1\n")
+    with pytest.raises(AssertionError, match="[Rr]atchet entries now compliant"):
+        mod_stale.test_file_budgets()

--- a/tests/unit/test_quality.py
+++ b/tests/unit/test_quality.py
@@ -303,6 +303,8 @@ class TestGenerateJustfile:
 
         # check should call quality and test-unit
         assert "check: quality test-unit" in content
+        # no test-arch generated → the comment must not claim structural gates
+        assert "structural gates" not in content
 
     def test_arch_target_in_check(self) -> None:
         plan = QualityPlan(

--- a/tests/unit/test_quality.py
+++ b/tests/unit/test_quality.py
@@ -59,6 +59,44 @@ class TestDetectQualityConfig:
         assert plan is not None
         assert plan.lint_cmd == "uv run ruff check src/ tests/"
 
+    def test_derives_test_arch_cmd(self, tmp_path: Path) -> None:
+        """Derives the structural-gates command from the unit test command."""
+        config_dir = tmp_path / ".devops-ai"
+        config_dir.mkdir()
+        (config_dir / "project.md").write_text(
+            "## Project\n\n"
+            "- **Name:** myapp\n"
+            "- **Language:** Python\n"
+            "- **Runner:** uv\n\n"
+            "## Testing\n\n"
+            "- **Unit tests:** uv run pytest tests/unit\n"
+            "- **Quality checks:** uv run ruff check src/ tests/ && uv run mypy src/\n"
+        )
+
+        plan = detect_quality_config(tmp_path)
+
+        assert plan is not None
+        assert plan.test_arch_cmd == "uv run pytest tests/architecture"
+
+    def test_no_arch_cmd_when_unit_path_unrecognized(self, tmp_path: Path) -> None:
+        """No tests/unit path in the unit command — nothing to derive from."""
+        config_dir = tmp_path / ".devops-ai"
+        config_dir.mkdir()
+        (config_dir / "project.md").write_text(
+            "## Project\n\n"
+            "- **Name:** myapp\n"
+            "- **Language:** TypeScript\n"
+            "- **Runner:** npm\n\n"
+            "## Testing\n\n"
+            "- **Unit tests:** npm test\n"
+            "- **Quality checks:** npm run lint\n"
+        )
+
+        plan = detect_quality_config(tmp_path)
+
+        assert plan is not None
+        assert plan.test_arch_cmd is None
+
     def test_derives_fix_cmd_for_python(self, tmp_path: Path) -> None:
         """Derives ruff --fix from quality command."""
         config_dir = tmp_path / ".devops-ai"
@@ -266,6 +304,28 @@ class TestGenerateJustfile:
         # check should call quality and test-unit
         assert "check: quality test-unit" in content
 
+    def test_arch_target_in_check(self) -> None:
+        plan = QualityPlan(
+            project_root=Path("/tmp/test"),
+            project_name="myapp",
+            language="python",
+            runner="uv",
+            lint_cmd="uv run ruff check src/",
+            quality_cmd="uv run ruff check src/",
+            test_unit_cmd="uv run pytest tests/unit",
+            test_e2e_cmd=None,
+            fix_cmd=None,
+            setup_cmd="uv sync --all-groups --all-extras",
+            test_arch_cmd="uv run pytest tests/architecture",
+        )
+
+        content = generate_justfile(plan)
+
+        assert "test-arch:" in content
+        assert "check: quality test-unit test-arch" in content
+        # guarded: projects that haven't adopted gates yet still pass check
+        assert "tests/architecture" in content
+
     def test_no_e2e_omits_target(self) -> None:
         plan = QualityPlan(
             project_root=Path("/tmp/test"),
@@ -344,6 +404,47 @@ class TestGenerateMakefile:
         content = generate_makefile(plan)
 
         assert "check: quality test-unit" in content
+
+    def test_arch_target_guarded_and_in_check(self) -> None:
+        plan = QualityPlan(
+            project_root=Path("/tmp/test"),
+            project_name="myapp",
+            language="python",
+            runner="uv",
+            lint_cmd="uv run ruff check src/",
+            quality_cmd="uv run ruff check src/",
+            test_unit_cmd="uv run pytest tests/unit",
+            test_e2e_cmd=None,
+            fix_cmd=None,
+            setup_cmd="uv sync --all-groups --all-extras",
+            test_arch_cmd="uv run pytest tests/architecture",
+        )
+
+        content = generate_makefile(plan)
+
+        assert "test-arch:" in content
+        assert "check: quality test-unit test-arch" in content
+        # guard keeps check green for projects that haven't adopted gates yet
+        assert 'if [ -d tests/architecture ]' in content
+
+    def test_no_arch_target_when_cmd_missing(self) -> None:
+        plan = QualityPlan(
+            project_root=Path("/tmp/test"),
+            project_name="myapp",
+            language="typescript",
+            runner="npm",
+            lint_cmd="npm run lint",
+            quality_cmd="npm run lint",
+            test_unit_cmd="npm test",
+            test_e2e_cmd=None,
+            fix_cmd=None,
+            setup_cmd="npm install",
+        )
+
+        content = generate_makefile(plan)
+
+        assert "test-arch:" not in content
+        assert "check: quality test-unit\n" in content
 
 
 # --- Pre-commit hook generator ---
@@ -518,7 +619,9 @@ class TestGenerateClaudeHooks:
         assert len(stop_rules) == 1
         assert stop_rules[0]["hooks"][0]["type"] == "command"
 
-    def test_runs_make_lint(self) -> None:
+    def test_stop_hook_blocks_on_make_check(self) -> None:
+        """The Stop hook is the loop's gate: a turn cannot end while make check
+        is red, so exit code 2 (block) — not a mere lint notice."""
         plan = QualityPlan(
             project_root=Path("/tmp/test"),
             project_name="myapp",
@@ -534,7 +637,12 @@ class TestGenerateClaudeHooks:
 
         content = generate_claude_hooks(plan)
 
-        assert "make lint" in content
+        import json
+        data = json.loads(content)
+        hook = data["hooks"]["Stop"][0]["hooks"][0]
+        assert "make check" in hook["command"]
+        assert "exit 2" in hook["command"]
+        assert hook["timeout"] >= 600
 
 
 # --- Conftest guardrails ---


### PR DESCRIPTION
## What this is

The workflow's diagnosed flaw: feedback loops existed for functionality only — Karl was the sole architecture sensor, and prose skills under-delivered on enforcement. This branch makes structure a machine-gated dimension and restructures execution around verifier-enforced loops, following a five-source research sweep (Cherny, Steinberger, Ralph ecosystem, lab evidence, Claude Code /goal machinery) whose consensus is: **a loop converges to whatever its verifier accepts; sophistication belongs in the verifier, not the prompt.**

## Commits in reading order

1. **Structural gates + ACP protocol** (`rules/structural-gates.md`, `templates/acp.md`, kbuild v0.3.0) — file budgets, layering, pattern uniqueness, test honesty; shrink-only ratchets; gate failures fixed in code, never by editing the gate; architecture evolves via reviewed proposals.
2. **Anti-theatre testing rules** (`rules/tdd.md`, `rules/testing-taxonomy.md`) — unit = behavior at the process boundary; fakes at I/O seams over patches; assert outcomes, not choreography.
3. **kdesign Enforcement table + kplan gate-harness/STRUCTURE tasks** — every structural decision names its check; M1 carries the gate harness.
4. **Verifier hardening** (`templates/test_invariants.py` + 17-test suite) — arming assertions (no vacuous pass), full patch detection (patch.object/dict, mocker, aliases, conftest), relative-import + dot-boundary layering, nested classes, first-party patch ratchet.
5. **kinfra wiring** — generated Makefile/Justfile get a guarded `test-arch` target inside `check`; the generated Stop hook now **blocks** (exit 2) while `make check` is red. Re-init propagates to every onboarded project.
6. **kplan v0.4.0: milestone files as goal state** — task checkboxes + per-task Verify commands; done = evidence, not the implementer's claim.
7. **kloop** (~60 lines) — one task per fresh context; `[ ]`/`[x]`/`[!]` states; the shell driver terminates on the file itself; escalation = `[!]` + ACP.
8. **kbuild frozen** as attended fallback; INTENT.md archived (provenance of the core observation).

## Validation

- 298 unit tests green (`make check`: ruff + mypy + pytest), including the new 17-test suite that loads the gates template against synthetic project trees and proves each gate fails when it must and stays quiet when it should.
- No E2E run: this repo's deliverables are skills/templates/generators; the real E2E is the first kloop-driven milestone on cashflow-pro (planned next, measured: interventions, gate catches, structure at close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)