### PR TITLE
security(ci): pin GitHub Actions to commit SHAs (refresh of #19)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
       - name: Install dependencies
         run: uv sync --all-groups --all-extras
       - name: Quality + tests

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,8 +18,8 @@ jobs:
   codeql:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
         with:
           languages: python
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3


### PR DESCRIPTION
Supersedes #19 (@lux-pit-ai's 2026-05-25 supply-chain PR, a fork branch), refreshed onto current `main`.

Pins every workflow `uses:` across `ci.yml` and `security.yml` to an immutable 40-char commit SHA (tj-actions / Shai-Hulud supply-chain mitigation), each annotated with its release tag. All SHAs verified to resolve to genuine upstream release tags:

| Action | SHA | Tag |
|---|---|---|
| actions/checkout | `34e1148` | v4.3.1 |
| actions/setup-python | `a26af69` | v5.6.0 |
| astral-sh/setup-uv | `38f3f10` | v4.2.0 |
| github/codeql-action (init+analyze) | `02c5e83` | v3 (current) |

Follow-ups (not in this PR): `astral-sh/setup-uv` is pinned at its declared major (v4; v5 exists) — a separate bump. Also enable Dependabot `github-actions` ecosystem so pins get bumped automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)