### PR TITLE
kinfra: impl/spec learn the v2 spec layout

### DIFF
--- a/skills/kworktree/SKILL.md
+++ b/skills/kworktree/SKILL.md
@@ -48,7 +48,7 @@ Create a design worktree (no sandbox).
 kinfra spec wellness-reminders
 # Creates: ../<prefix>-spec-wellness-reminders/
 # Branch: spec/wellness-reminders
-# Design dir: docs/designs/wellness-reminders/
+# Spec dir: docs/specs/wellness-reminders/
 ```
 
 ### `kinfra impl <feature>/<milestone> [--no-session]`

--- a/src/devops_ai/cli/impl.py
+++ b/src/devops_ai/cli/impl.py
@@ -59,18 +59,24 @@ def parse_feature_milestone(arg: str) -> tuple[str, str]:
 def _find_milestone_file(
     repo_root: Path, feature: str, milestone: str
 ) -> Path | None:
-    """Find milestone file matching the pattern."""
-    impl_dir = (
-        repo_root / "docs" / "designs" / feature / "implementation"
+    """Find the milestone's brief (v2 contract) or milestone file (v1 layout).
+
+    v2: docs/specs/<feature>/briefs/<milestone>-*.md — preferred.
+    v1: docs/designs/<feature>/implementation/<milestone>_*.md — fallback.
+    """
+    candidates = (
+        (repo_root / "docs" / "specs" / feature / "briefs", f"{milestone}-*.md"),
+        (
+            repo_root / "docs" / "designs" / feature / "implementation",
+            f"{milestone}_*.md",
+        ),
     )
-    if not impl_dir.is_dir():
-        return None
-    matches = list(impl_dir.glob(f"{milestone}_*.md"))
-    if len(matches) == 1:
-        return matches[0]
-    if len(matches) > 1:
-        # Prefer exact prefix match
-        return matches[0]
+    for directory, pattern in candidates:
+        if not directory.is_dir():
+            continue
+        matches = sorted(directory.glob(pattern))
+        if matches:
+            return matches[0]
     return None
 
 
@@ -109,9 +115,10 @@ def impl_command(
     ms_file = _find_milestone_file(repo_root, feature, milestone)
     if ms_file is None:
         return 1, (
-            f"No milestone file found matching "
-            f"'{milestone}_*.md' in "
-            f"docs/designs/{feature}/implementation/"
+            f"No brief found for {milestone}: expected "
+            f"docs/specs/{feature}/briefs/{milestone}-*.md "
+            f"(or the v1 layout docs/designs/{feature}/implementation/"
+            f"{milestone}_*.md)"
         )
 
     # Check worktree doesn't already exist

--- a/src/devops_ai/cli/impl.py
+++ b/src/devops_ai/cli/impl.py
@@ -115,10 +115,10 @@ def impl_command(
     ms_file = _find_milestone_file(repo_root, feature, milestone)
     if ms_file is None:
         return 1, (
-            f"No brief found for {milestone}: expected "
-            f"docs/specs/{feature}/briefs/{milestone}-*.md "
-            f"(or the v1 layout docs/designs/{feature}/implementation/"
-            f"{milestone}_*.md)"
+            f"No brief or milestone file found for {milestone}. Searched "
+            f"docs/specs/{feature}/briefs/{milestone}-*.md (v2 contract) and "
+            f"docs/designs/{feature}/implementation/{milestone}_*.md "
+            f"(v1 layout)"
         )
 
     # Check worktree doesn't already exist

--- a/src/devops_ai/cli/spec.py
+++ b/src/devops_ai/cli/spec.py
@@ -37,5 +37,5 @@ def spec_command(feature: str, repo_root: Path | None = None) -> int:
 
     typer.echo(f"Created spec worktree: {wt_path}")
     typer.echo(f"  Branch: spec/{feature}")
-    typer.echo(f"  Design dir: {wt_path / 'docs' / 'designs' / feature}")
+    typer.echo(f"  Spec dir: {wt_path / 'docs' / 'specs' / feature}")
     return 0

--- a/src/devops_ai/worktree.py
+++ b/src/devops_ai/worktree.py
@@ -95,7 +95,7 @@ def _fetch_and_resolve_start_point(repo_root: Path) -> str | None:
 def create_spec_worktree(
     repo_root: Path, prefix: str, feature: str
 ) -> Path:
-    """Create a spec worktree and its design directory."""
+    """Create a spec worktree and its spec directory (v2 layout)."""
     validate_feature_name(feature)
     wt_path = spec_worktree_path(repo_root, prefix, feature)
     branch = spec_branch_name(feature)
@@ -107,9 +107,10 @@ def create_spec_worktree(
 
     _run_git(cmd, cwd=repo_root)
 
-    # Create design directory in the worktree
-    design_dir = wt_path / "docs" / "designs" / feature
-    design_dir.mkdir(parents=True, exist_ok=True)
+    # Create the v2 spec directory in the worktree (docs/specs/<feature>/),
+    # matching the path `kinfra spec` prints and the layout /kspec writes into.
+    spec_dir = wt_path / "docs" / "specs" / feature
+    spec_dir.mkdir(parents=True, exist_ok=True)
 
     return wt_path
 

--- a/tests/integration/test_worktree.py
+++ b/tests/integration/test_worktree.py
@@ -5,11 +5,13 @@ from pathlib import Path
 
 import pytest
 
+from devops_ai.cli.spec import spec_command
 from devops_ai.worktree import (
     check_dirty,
     create_spec_worktree,
     list_worktrees,
     remove_worktree,
+    spec_worktree_path,
 )
 
 
@@ -49,11 +51,31 @@ class TestCreateAndRemoveSpecWorktree:
         )
         assert wt_path.exists()
         assert wt_path.name == "test-spec-my-feature"
-        # Design directory created
-        assert (wt_path / "docs" / "designs" / "my-feature").is_dir()
+        # v2 spec directory created — and not the v1 design directory
+        assert (wt_path / "docs" / "specs" / "my-feature").is_dir()
+        assert not (wt_path / "docs" / "designs" / "my-feature").exists()
 
         remove_worktree(git_repo, wt_path)
         assert not wt_path.exists()
+
+    def test_printed_spec_dir_is_the_one_created(
+        self, git_repo: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Every directory `kinfra spec` reports must actually exist."""
+        assert spec_command("my-feature", repo_root=git_repo) == 0
+
+        out = capsys.readouterr().out
+        wt_path = spec_worktree_path(git_repo, git_repo.name, "my-feature")
+        try:
+            reported = [
+                line.split(":", 1)[1].strip()
+                for line in out.splitlines()
+                if line.strip().startswith("Spec dir:")
+            ]
+            assert reported == [str(wt_path / "docs" / "specs" / "my-feature")]
+            assert Path(reported[0]).is_dir()
+        finally:
+            remove_worktree(git_repo, wt_path)
 
 
 class TestDirtyCheck:

--- a/tests/unit/test_cli_impl.py
+++ b/tests/unit/test_cli_impl.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from devops_ai.cli.impl import parse_feature_milestone
+from pathlib import Path
+
+from devops_ai.cli.impl import _find_milestone_file, parse_feature_milestone
 
 
 class TestParseFeatureMilestone:
@@ -18,3 +20,36 @@ class TestParseFeatureMilestone:
             raise AssertionError("Should have raised")
         except ValueError as e:
             assert "feature/milestone" in str(e).lower()
+
+
+class TestFindMilestoneFile:
+    def test_v2_brief_layout(self, tmp_path: Path) -> None:
+        briefs = tmp_path / "docs" / "specs" / "challenges" / "briefs"
+        briefs.mkdir(parents=True)
+        brief = briefs / "M1-run-day-one.md"
+        brief.write_text("---\nmilestone: M1\n---\n")
+
+        assert _find_milestone_file(tmp_path, "challenges", "M1") == brief
+        assert _find_milestone_file(tmp_path, "challenges", "M2") is None
+
+    def test_v1_layout_still_found(self, tmp_path: Path) -> None:
+        impl = tmp_path / "docs" / "designs" / "auth" / "implementation"
+        impl.mkdir(parents=True)
+        ms = impl / "M1_login.md"
+        ms.write_text("# M1")
+
+        assert _find_milestone_file(tmp_path, "auth", "M1") == ms
+
+    def test_v2_preferred_over_v1(self, tmp_path: Path) -> None:
+        briefs = tmp_path / "docs" / "specs" / "f" / "briefs"
+        briefs.mkdir(parents=True)
+        (briefs / "M1-x.md").write_text("v2")
+        impl = tmp_path / "docs" / "designs" / "f" / "implementation"
+        impl.mkdir(parents=True)
+        (impl / "M1_x.md").write_text("v1")
+
+        found = _find_milestone_file(tmp_path, "f", "M1")
+        assert found is not None and found.read_text() == "v2"
+
+    def test_missing(self, tmp_path: Path) -> None:
+        assert _find_milestone_file(tmp_path, "nothing", "M1") is None

--- a/tests/unit/test_cli_impl.py
+++ b/tests/unit/test_cli_impl.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from devops_ai.cli.impl import _find_milestone_file, parse_feature_milestone
+from devops_ai.cli.impl import (
+    _find_milestone_file,
+    impl_command,
+    parse_feature_milestone,
+)
 
 
 class TestParseFeatureMilestone:
@@ -53,3 +57,15 @@ class TestFindMilestoneFile:
 
     def test_missing(self, tmp_path: Path) -> None:
         assert _find_milestone_file(tmp_path, "nothing", "M1") is None
+
+
+class TestMissingBriefMessage:
+    def test_names_both_searched_locations(self, tmp_path: Path) -> None:
+        """The failure names the v2 brief path and the v1 fallback path."""
+        code, message = impl_command(
+            "challenges/M1", repo_root=tmp_path, session=False
+        )
+
+        assert code == 1
+        assert "docs/specs/challenges/briefs/M1-*.md" in message
+        assert "docs/designs/challenges/implementation/M1_*.md" in message


### PR DESCRIPTION
\`kinfra impl\` gated on the v1 milestone file layout and refused to create a worktree for a v2 feature (brief at \`docs/specs/<feature>/briefs/M<N>-*.md\`) — found on the pilot's first executor start. The lookup now prefers the v2 brief with the v1 file as fallback, the error message names both, and \`kinfra spec\` reports the v2 spec dir. Unit tests cover v2, v1, precedence, and missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BB7sPh33JC8Q4ANWkhq1Ff